### PR TITLE
Display multiple verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add comments above your Rails actions that look like:
 
 ```ruby
-# @route GET /waterlilies/:id (waterlily)
+# @route [GET] /waterlilies/:id (waterlily)
 def show
   # ...
 end

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -75,10 +75,10 @@ module Chusaku
   # @param {Hash} action_info
   # @return {String}
   def self.annotate(action_info)
-    verb = action_info[:verb]
+    verbs = action_info[:verbs]
     path = action_info[:path]
     name = action_info[:name]
-    annotation = "@route #{verb} #{path}"
+    annotation = "@route [#{verbs.join(', ')}] #{path}"
     annotation += " (#{name})" unless name.nil?
     annotation
   end

--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -8,11 +8,23 @@ module Chusaku
     #
     #   {
     #     'users' => {
-    #       'edit'   => { verbs: 'GET', path: '/users/:id', name: 'edit_user' },
-    #       'update' => { verbs: 'PUT', path: '/users',     name: nil }
+    #       'edit' => {
+    #         verbs: ['GET'],
+    #         path: '/users/:id',
+    #         name: 'edit_user'
+    #       },
+    #       'update' => {
+    #         verbs: ['PUT', 'PATCH'],
+    #         path: '/users', 
+    #         name: nil
+    #       }
     #     },
     #     'empanadas' => {
-    #       'create' => { verbs: 'POST', path: '/empanadas', name: nil }
+    #       'create' => {
+    #         verbs: ['POST'],
+    #         path: '/empanadas',
+    #         name: nil
+    #       }
     #     }
     #   }
     #

--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -8,11 +8,11 @@ module Chusaku
     #
     #   {
     #     'users' => {
-    #       'edit'   => { verb: 'GET', path: '/users/:id', name: 'edit_user' },
-    #       'update' => { verb: 'PUT', path: '/users',     name: nil }
+    #       'edit'   => { verbs: 'GET', path: '/users/:id', name: 'edit_user' },
+    #       'update' => { verbs: 'PUT', path: '/users',     name: nil }
     #     },
     #     'empanadas' => {
-    #       'create' => { verb: 'POST', path: '/empanadas', name: nil }
+    #       'create' => { verbs: 'POST', path: '/empanadas', name: nil }
     #     }
     #   }
     #
@@ -22,18 +22,32 @@ module Chusaku
 
       Rails.application.routes.routes.each do |route|
         defaults = route.defaults
+        controller = defaults[:controller]
         action = defaults[:action]
 
-        routes[defaults[:controller]] ||= {}
-        routes[defaults[:controller]][action] =
-          {
-            verb: route.verb,
-            path: route.path.spec.to_s.gsub('(.:format)', ''),
-            name: route.name
-          }
+        routes[controller] ||= {}
+        if routes[controller][action].nil?
+          routes[controller][action] = format_action(route)
+        else
+          routes[controller][action][:verbs].push(route.verb)
+        end
       end
 
       routes
     end
+
+    private
+
+      # Extract information of a given route.
+      #
+      # @param {ActionDispatch::Journey::Route} route
+      # @return {Hash}
+      def self.format_action(route)
+        {
+          verbs: [route.verb],
+          path: route.path.spec.to_s.gsub('(.:format)', ''),
+          name: route.name
+        }
+      end
   end
 end

--- a/lib/chusaku/version.rb
+++ b/lib/chusaku/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Chusaku
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -13,13 +13,13 @@ class ChusakuTest < Minitest::Test
         # frozen_string_literal: true
 
         class TacosController < ApplicationController
-          # @route POST /api/tacos
+          # @route [POST] /api/tacos
           def create; end
 
           # Update all the tacos!
           # We should not see a duplicate @route in this comment block.
           # But this should remain (@route), because it's just words.
-          # @route PUT /api/tacos/:id
+          # @route [PUT, PATCH] /api/tacos/:id
           def update; end
 
           # This route doesn't exist, so it should be deleted.
@@ -41,7 +41,7 @@ class ChusakuTest < Minitest::Test
         # frozen_string_literal: true
 
         class WaterliliesController < ApplicationController
-          # @route GET /waterlilies/:id (waterlilies)
+          # @route [GET] /waterlilies/:id (waterlilies)
           def show; end
         end
       HEREDOC

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -20,7 +20,7 @@ module Rails
     taco_create.expect(:name, nil)
     routes.push(taco_create)
 
-    # Mock tacos#update route.
+    # Mock tacos#update PUT route.
     taco_update = Minitest::Mock.new
     taco_update.expect(:defaults, controller: 'api/tacos', action: 'update')
     taco_update.expect(:verb, 'PUT')
@@ -29,6 +29,16 @@ module Rails
     taco_update.expect(:path, taco_update_path)
     taco_update.expect(:name, nil)
     routes.push(taco_update)
+
+    # Mock tacos#update PATCH route.
+    taco_patch = Minitest::Mock.new
+    taco_patch.expect(:defaults, controller: 'api/tacos', action: 'update')
+    taco_patch.expect(:verb, 'PATCH')
+    taco_patch_path = Minitest::Mock.new
+    taco_patch_path.expect(:spec, '/api/tacos/:id(.:format)')
+    taco_patch.expect(:path, taco_patch_path)
+    taco_patch.expect(:name, nil)
+    routes.push(taco_patch)
 
     # Mock waterlilies#show route.
     wl_show = Minitest::Mock.new

--- a/test/routes/routes_test.rb
+++ b/test/routes/routes_test.rb
@@ -7,12 +7,20 @@ class RoutesTest < Minitest::Test
     expected =
       {
         'api/tacos' => {
-          'create' => { verb: 'POST', path: '/api/tacos', name: nil },
-          'update' => { verb: 'PUT', path: '/api/tacos/:id', name: nil }
+          'create' => {
+            verbs: %w(POST),
+            path: '/api/tacos',
+            name: nil
+          },
+          'update' => {
+            verbs: %w(PUT PATCH),
+            path: '/api/tacos/:id',
+            name: nil
+          }
         },
         'waterlilies' => {
           'show' => {
-            verb: 'GET',
+            verbs: %w(GET),
             path: '/waterlilies/:id',
             name: 'waterlilies'
           }


### PR DESCRIPTION
Previously, each `@route` comment displayed only one verb like such:

```ruby
# @route PUT /api/tacos/:id
```

But with this PR, multiple verbs are allowed like the following:

```ruby
# @route [PUT, PATCH] /api/tacos/:id
```

Brackets are now used to wrap verbs regardless of how many there are as well. They are easier to parse when glancing at a `@route` comment.