### PR TITLE
Remove `ruby-progressbar` and favor plain output

### DIFF
--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -45,6 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
 
-  spec.add_dependency 'rails', '> 4.2'
-  spec.add_dependency 'ruby-progressbar', '~> 1.10.1'
+  spec.add_dependency 'rails', '> 2.0'
 end

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby-progressbar'
 require 'chusaku/version'
 require 'chusaku/parser'
 require 'chusaku/routes'
@@ -18,14 +17,8 @@ module Chusaku
     controller_pattern = 'app/controllers/**/*_controller.rb'
     controller_paths = Dir.glob(Rails.root.join(controller_pattern))
 
-    # Start progress bar.
-    progressbar = ProgressBar.create \
-      title: 'Chusaku',
-      total: controller_paths.count
-
     # Loop over all controller file paths.
     controller_paths.each do |path|
-      progressbar.increment
       controller = /controllers\/(.*)_controller\.rb/.match(path)[1]
       actions = routes[controller]
       next if actions.nil?
@@ -59,6 +52,13 @@ module Chusaku
       # Write to file.
       parsed_content = parsed_file.map { |pf| pf[:body] }
       write(path, parsed_content.join)
+    end
+
+    # Output results to user.
+    if controller_paths.any?
+      puts "Annotated #{controller_paths.join(', ')}"
+    else
+      puts "Nothing to annotate"
     end
   end
 


### PR DESCRIPTION
This PR removes `ruby-progressbar` as a dependency because:

1. The less dependencies the better so more apps can incorporate the latest version of Chusaku
2. It's more useful to have a full output of all annotated files in the end anyway