### PR TITLE
Add CLI flags

### DIFF
--- a/bin/chusaku
+++ b/bin/chusaku
@@ -1,9 +1,5 @@
 #!/usr/bin/env ruby
 
-unless File.directory?('./app/controllers') && File.exist?('./Rakefile')
-  abort 'Please run chusaku from the root of your project.'
-end
-
 require 'rubygems'
 
 begin
@@ -18,5 +14,6 @@ begin
 rescue StandardError
 end
 
-require 'chusaku'
-exit Chusaku.call(ARGV)
+require 'chusaku/cli'
+
+exit Chusaku::CLI.new.call

--- a/bin/chusaku
+++ b/bin/chusaku
@@ -19,4 +19,4 @@ rescue StandardError
 end
 
 require 'chusaku'
-Chusaku.call
+exit Chusaku.call(ARGV)

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -13,8 +13,8 @@ module Chusaku
   #     # ...
   #   end
   #
-  # @param {Array<String>} args - List cli flags
-  # @return {Integer}
+  # @param {Array<String>} args - CLI flags
+  # @return {Integer} 0 on success, 1 on error
   def self.call(args = [])
     routes = Chusaku::Routes.call
     controller_pattern = 'app/controllers/**/*_controller.rb'
@@ -57,7 +57,7 @@ module Chusaku
       parsed_content = parsed_file[:groups].map { |pf| pf[:body] }
       new_content = parsed_content.join
       if parsed_file[:content] != new_content
-        write(path, new_content) unless args.include?('--dry-run')
+        write(path, new_content) unless args.include?(:dry)
         annotated_paths << path
       end
     end
@@ -65,7 +65,7 @@ module Chusaku
     # Output results to user.
     if annotated_paths.any?
       puts "Annotated #{annotated_paths.join(', ')}"
-      if args.include?('--exit-with-error-on-annotation')
+      if args.include?(:error_on_annotation)
         1
       else
         0

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'chusaku'
+
+module Chusaku
+  class CLI
+    STATUS_SUCCESS = 0
+    STATUS_ERROR = 1
+
+    attr_reader :options
+
+    Finished = Class.new(RuntimeError)
+    NotARailsProject = Class.new(RuntimeError)
+
+    def initialize
+      @options = {}
+    end
+
+    def call(args = ARGV)
+      optparser.parse!(args)
+
+      check_for_rails_project
+
+      Chusaku.call(options)
+    rescue NotARailsProject
+      warn('Please run chusaku from the root of your project.')
+      STATUS_ERROR
+    rescue Finished
+      STATUS_SUCCESS
+    end
+
+    private
+
+    def check_for_rails_project
+      unless File.directory?('./app/controllers') && File.exist?('./Rakefile')
+        raise NotARailsProject
+      end
+    end
+
+    def optparser
+      OptionParser.new do |opts|
+        opts.banner = 'Usage: chusaku [options]'
+        opts.on('--exit-with-error-on-annotation', 'Fail if any file was annotated') do |arg|
+          @options[:error_on_annotation] = true
+        end
+        opts.on('--dry-run', 'Run without file modifications') do |arg|
+          @options[:dry] = true
+        end
+        opts.on('-v', '--version', 'Show Chusaku version number and quit') do |arg|
+          puts(Chusaku::VERSION)
+          raise Finished
+        end
+        opts.on('-h', '--help', 'Show this help message and quit') do
+          puts(opts)
+          raise Finished
+        end
+      end
+    end
+  end
+end

--- a/lib/chusaku/parser.rb
+++ b/lib/chusaku/parser.rb
@@ -21,12 +21,13 @@ module Chusaku
     #
     # @param {String} path - File path to parse
     # @param {Array<String>} actions - List of valid actions for this route
-    # @return {Array<Hash>} Parsed groups of the file
+    # @return {Hash} Parsed groups of the file
     def self.call(path:, actions:)
       groups = []
       group = {}
+      content = IO.read(path)
 
-      File.open(path, 'r').each_line do |line|
+      content.each_line do |line|
         parsed_line = parse_line(line: line, actions: actions)
 
         if group[:type] != parsed_line[:type]
@@ -42,7 +43,10 @@ module Chusaku
 
       # Push the last group onto the array and return.
       groups.push(group)
-      groups
+      {
+        content: content,
+        groups: groups
+      }
     end
 
     # Given a line and actions, returns the line's type:

--- a/lib/chusaku/parser.rb
+++ b/lib/chusaku/parser.rb
@@ -21,7 +21,7 @@ module Chusaku
     #
     # @param {String} path - File path to parse
     # @param {Array<String>} actions - List of valid actions for this route
-    # @return {Hash} Parsed groups of the file
+    # @return {Hash} Parsed groups of the file and original content
     def self.call(path:, actions:)
       groups = []
       group = {}

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -4,26 +4,25 @@ require 'test_helper'
 
 class ChusakuTest < Minitest::Test
   def test_dry_run_flag
-    capture_io do
-      Chusaku.call('--dry-run')
-    end
-    assert_empty File.written_files
+    File.reset_mock
+    capture_io { Chusaku.call([:dry]) }
+    assert_empty(File.written_files)
   end
 
   def test_exit_with_error_on_annotation_flag
-    assert_empty File.written_files
+    assert_empty(File.written_files)
     capture_io do
-      assert_equal 1, Chusaku.call('--exit-with-error-on-annotation')
+      assert_equal(1, Chusaku.call([:error_on_annotation]))
     end
-    assert_equal 2, File.written_files.size
+    assert_equal(2, File.written_files.size)
   end
 
   def test_mock_app
-    capture_io do
-      Chusaku.call
-    end
+    capture_io { Chusaku.call }
     files = File.written_files
     base_path = 'test/mock/app/controllers'
+
+    refute_includes(files, "#{base_path}/api/burritos_controller.rb")
 
     expected =
       <<~HEREDOC

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -3,8 +3,25 @@
 require 'test_helper'
 
 class ChusakuTest < Minitest::Test
+  def test_dry_run_flag
+    capture_io do
+      Chusaku.call('--dry-run')
+    end
+    assert_empty File.written_files
+  end
+
+  def test_exit_with_error_on_annotation_flag
+    assert_empty File.written_files
+    capture_io do
+      assert_equal 1, Chusaku.call('--exit-with-error-on-annotation')
+    end
+    assert_equal 2, File.written_files.size
+  end
+
   def test_mock_app
-    Chusaku.call
+    capture_io do
+      Chusaku.call
+    end
     files = File.written_files
     base_path = 'test/mock/app/controllers'
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Chusaku::CLITest < Minitest::Test
+  def test_help_flag
+    out, _ = capture_io do
+      assert_equal(0, Chusaku::CLI.new.call(['-h']))
+    end
+    assert_match(/Show this help message and quit/, out)
+    out, _ = capture_io do
+      assert_equal(0, Chusaku::CLI.new.call(['--help']))
+    end
+    assert_match(/Show this help message and quit/, out)
+  end
+
+  def test_version_flag
+    out, _ = capture_io do
+      assert_equal(0, Chusaku::CLI.new.call(['-v']))
+    end
+    assert_match(/\d+\.\d+\.\d+/, out)
+  end
+
+  def test_exit_flag_precedence
+    out, _ = capture_io do
+      assert_equal(0, Chusaku::CLI.new.call(['-v', '-h']))
+    end
+    assert_match(/\d+\.\d+\.\d+/, out)
+    refute_match(/Show this help message and quit/, out)
+
+    out, _ = capture_io do
+      assert_equal(0, Chusaku::CLI.new.call(['-h', '-v']))
+    end
+    assert_match(/Show this help message and quit/, out)
+    refute_match(/\d+\.\d+\.\d+/, out)
+  end
+
+  def test_project_detection
+    _, err = capture_io do
+      assert_equal(1, Chusaku::CLI.new.call([]))
+    end
+    assert_equal(<<~ERR, err)
+      Please run chusaku from the root of your project.
+    ERR
+  end
+
+  def test_dry_flag
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(['--dry-run']))
+      end
+      assert_equal({ dry: true }, cli.options)
+    end
+  end
+
+  def test_exit_with_error_on_annotation_flag
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(1, cli.call(['--exit-with-error-on-annotation']))
+      end
+      assert_equal({ error_on_annotation: true }, cli.options)
+    end
+  end
+end

--- a/test/mock/app/controllers/api/burritos_controller.rb
+++ b/test/mock/app/controllers/api/burritos_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class BurritosController < ApplicationController
+  # @route POST /api/burritos (burritos)
+  def create; end
+end

--- a/test/mock/file.rb
+++ b/test/mock/file.rb
@@ -15,10 +15,17 @@ class File
 
   # Get the content of files in memory.
   #
-  # @return {Array<String>} List of files and their contents
+  # @return {Hash} Mapping of files to their contents
   def self.written_files
     written_files = @@written_files
-    @@written_files = {}
+    reset_mock
     written_files
+  end
+
+  # Reset in memory cache.
+  #
+  # @return {void}
+  def self.reset_mock
+    @@written_files = {}
   end
 end

--- a/test/mock/file.rb
+++ b/test/mock/file.rb
@@ -18,7 +18,7 @@ class File
   # @return {Array<String>} List of files and their contents
   def self.written_files
     written_files = @@written_files
-    @@written_files = []
+    @@written_files = {}
     written_files
   end
 end

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -12,6 +12,13 @@ module Rails
 
     routes.push \
       mock_route \
+        controller: 'api/burritos',
+        action: 'create',
+        verb: 'POST',
+        path: '/api/burritos(.:format)',
+        name: 'burritos'
+    routes.push \
+      mock_route \
         controller: 'api/tacos',
         action: 'show',
         verb: 'GET',

--- a/test/parser/parser_test.rb
+++ b/test/parser/parser_test.rb
@@ -8,16 +8,16 @@ class ParserTest < Minitest::Test
       path: "#{__dir__}/examples/example.rb",
       actions: %w[foo]
 
-    assert_equal(5, result.size)
+    assert_equal(5, result[:groups].size)
     assert_equal \
       %i[comment code comment action code],
-      (result.map { |r| r[:type] })
+      (result[:groups].map { |r| r[:type] })
     assert_equal \
-      result.map { |r| r[:body] }.join,
+      result[:groups].map { |r| r[:body] }.join,
       File.read("#{__dir__}/examples/example.rb")
     assert_equal \
       [nil, nil, nil, 'foo', nil],
-      (result.map { |r| r[:action] })
+      (result[:groups].map { |r| r[:action] })
   end
 
   def test_empty_file
@@ -25,7 +25,7 @@ class ParserTest < Minitest::Test
       path: "#{__dir__}/examples/empty.rb",
       actions: []
 
-    assert_equal([{}], result)
+    assert_equal([{}], result[:groups])
   end
 
   def test_comment

--- a/test/routes/routes_test.rb
+++ b/test/routes/routes_test.rb
@@ -6,6 +6,11 @@ class RoutesTest < Minitest::Test
   def test_mock_rails
     expected =
       {
+        'api/burritos' => {
+          'create' => [
+            { verb: 'POST', path: '/api/burritos', name: 'burritos' }
+          ]
+        },
         'api/tacos' => {
           'show' => [
             { verb: 'GET', path: '/', name: 'root' },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,5 +4,5 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'mock/rails'
 require 'mock/file'
-require 'chusaku'
+require 'chusaku/cli'
 require 'minitest/autorun'


### PR DESCRIPTION
Hi!

Thank you for the great tool. We recently adopted it and very happy with the result. One thing we stumbled upon is automation.

Current behaviour is to annotate everything and report all of the files. If someone added new route and did not know that `chusaku` needs to be invoked, we'll have synchronisation issue between comments and code.

There are couple solutions I see:

- run it on CI and fail if new annotations added;
- run in the git hook and prevent commit/push if new annotation added;

To be able to do it we need a way to report back on changes (status code, what was changed).

I added couple of flags to be able to achieve this.

What do you think?