### PR TITLE
Account for regular expressions containing multiple verbs

### DIFF
--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -47,14 +47,14 @@ module Rails
         mock_route \
           controller: 'api/tacos',
           action: 'update',
-          verb: 'PUT',
+          verb: /^PUT|PATCH$/,
           path: '/api/tacos/:id(.:format)',
           name: nil
       routes.push \
         mock_route \
           controller: 'api/tacos',
           action: 'update',
-          verb: 'PATCH',
+          verb: 'PUT',
           path: '/api/tacos/:id(.:format)',
           name: nil
       routes.push \
@@ -113,9 +113,15 @@ module Rails
       route.expect(:defaults, controller: controller, action: action)
       route.expect(:verb, verb)
       route_path = Minitest::Mock.new
-      route_path.expect(:spec, path)
-      route.expect(:path, route_path)
-      route.expect(:name, name)
+
+      # We'll be calling these particular methods more than once to test for
+      # duplicate-removal, hence wrapping in `.times` block.
+      2.times do
+        route_path.expect(:spec, path)
+        route.expect(:path, route_path)
+        route.expect(:name, name)
+      end
+
       route
     end
   end


### PR DESCRIPTION
# Problem

Older versions of Rails (e.g. 4.2) return regular expressions instead of strings for a route verb. This results in Chusaku outputting routes that may look like:

```ruby
# @route (?-mix:^GET$) /some/path (helper_to_path)
```


# Solution

Account for said regular expressions that may be returned by a route verb, extract HTTP verbs being used, and remove duplicates.