### PR TITLE
Fix invalid file content trails

### DIFF
--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'byebug', '~> 11.1'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.77'

--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'byebug', '~> 11.1'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.77'

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -98,7 +98,11 @@ module Chusaku
       return unless parsed_file[:content] != content
 
       unless @flags.include?(:dry)
-        File.open(path, 'w') do |file|
+        # When running the test suite, we want to make sure we're not
+        # overwriting any files. `r` mode ensures that.
+        mode = File.instance_methods.include?(:test_write) ? 'r' : 'w'
+
+        File.open(path, mode) do |file|
           if file.respond_to?(:test_write)
             file.test_write(content, path)
           else

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -98,7 +98,7 @@ module Chusaku
       return unless parsed_file[:content] != content
 
       unless @flags.include?(:dry)
-        File.open(path, 'r+') do |file|
+        File.open(path, 'w') do |file|
           if file.respond_to?(:test_write)
             file.test_write(content, path)
           else


### PR DESCRIPTION
# Outcome

Files that end up shorter than they were originally will no longer have "remnants" of what the previous contents were.


# Problem

Due to Chusaku using `File.open(file, 'r+')`, files that ended up shorter as a result of the executable kept old file contents trailing after the newly written contents.


# Solution

Switch to using `w` mode with `File`.