### PR TITLE
Show defaults in controller annotation

### DIFF
--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -91,8 +91,8 @@ module Chusaku
     # @param {String} path - Rails path for route
     # @param {String} name - Name used in route helpers
     # @param {Hash} defaults - Default parameters for route
-    # @return {String} - @route <verb> <path> {<defaults>} (<name>)
-    def annotate_route(verb:, path:, name:, defaults:, **)
+    # @return {String} - "@route <verb> <path> {<defaults>} (<name>)"
+    def annotate_route(verb:, path:, name:, defaults:)
       annotation = "@route #{verb} #{path}"
       if defaults&.any?
         defaults_str =

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -85,13 +85,13 @@ module Chusaku
       end
     end
 
-    # Generate route annotation
+    # Generate route annotation.
     #
-    # @param {String} verb
-    # @param {String} path
-    # @param {String} name
-    # @param {Hash} defaults
-    # @return {String}
+    # @param {String} verb - HTTP verb for route
+    # @param {String} path - Rails path for route
+    # @param {String} name - Name used in route helpers
+    # @param {Hash} defaults - Default parameters for route
+    # @return {String} - @route <verb> <path> {<defaults>} (<name>)
     def annotate_route(verb:, path:, name:, defaults:, **)
       annotation = "@route #{verb} #{path}"
       if defaults&.any?

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -81,7 +81,9 @@ module Chusaku
       whitespace = /^(\s*).*$/.match(group[:body])[1]
       route_data.reverse_each do |datum|
         name = datum[:name]
+        defaults = datum[:defaults]
         annotation = "@route #{datum[:verb]} #{datum[:path]}"
+        annotation += inspect_defaults(defaults) unless defaults.nil? || defaults.empty?
         annotation += " (#{name})" unless name.nil?
         comment = "#{whitespace}# #{annotation}\n"
         group[:body] = comment + group[:body]
@@ -147,6 +149,10 @@ module Chusaku
         puts('Nothing to annotate')
         0
       end
+    end
+
+    def inspect_defaults(hash)
+      '{' + hash.map { |key, value| "#{key}: #{value.inspect}" }.join(', ') + '}'
     end
   end
 end

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -80,14 +80,29 @@ module Chusaku
     def annotate_group(group:, route_data:)
       whitespace = /^(\s*).*$/.match(group[:body])[1]
       route_data.reverse_each do |datum|
-        name = datum[:name]
-        defaults = datum[:defaults]
-        annotation = "@route #{datum[:verb]} #{datum[:path]}"
-        annotation += inspect_defaults(defaults) unless defaults.nil? || defaults.empty?
-        annotation += " (#{name})" unless name.nil?
-        comment = "#{whitespace}# #{annotation}\n"
+        comment = "#{whitespace}# #{annotate_route(**datum)}\n"
         group[:body] = comment + group[:body]
       end
+    end
+
+    # Generate route annotation
+    #
+    # @param {String} verb
+    # @param {String} path
+    # @param {String} name
+    # @param {Hash} defaults
+    # @return {String}
+    def annotate_route(verb:, path:, name:, defaults:, **)
+      annotation = "@route #{verb} #{path}"
+      if defaults&.any?
+        defaults_str =
+          defaults
+          .map { |key, value| "#{key}: #{value.inspect}" }
+          .join(', ')
+        annotation += " {#{defaults_str}}"
+      end
+      annotation += " (#{name})" unless name.nil?
+      annotation
     end
 
     # Write annotated content to a file if it differs from the original.
@@ -149,10 +164,6 @@ module Chusaku
         puts('Nothing to annotate')
         0
       end
-    end
-
-    def inspect_defaults(hash)
-      ' {' + hash.map { |key, value| "#{key}: #{value.inspect}" }.join(', ') + '}'
     end
   end
 end

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -152,7 +152,7 @@ module Chusaku
     end
 
     def inspect_defaults(hash)
-      '{' + hash.map { |key, value| "#{key}: #{value.inspect}" }.join(', ') + '}'
+      ' {' + hash.map { |key, value| "#{key}: #{value.inspect}" }.join(', ') + '}'
     end
   end
 end

--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -50,7 +50,8 @@ module Chusaku
       # @param {Hash} route - Route info
       # @param {Hash} routes - Collection of all route info
       # @param {String} controller - Controller key
-      # @param {STring} action - Action key
+      # @param {String} action - Action key
+      # @param {Hash} defaults - Default parameters for route
       # @return {void}
       def add_info_for(route:, routes:, controller:, action:, defaults:)
         verbs_for(route).each do |verb|
@@ -78,6 +79,7 @@ module Chusaku
       #
       # @param {ActionDispatch::Journey::Route} route - Route given by Rails
       # @param {String} verb - HTTP verb
+      # @param {Hash} defaults - Default parameters for route
       # @return {Hash} - { verb: String, path: String, name: String }
       def format(route:, verb:, defaults:)
         {
@@ -111,7 +113,7 @@ module Chusaku
       # Given a route, extract the controller and action strings.
       #
       # @param {ActionDispatch::Journey::Route} route - Route instance
-      # @return {Array<String>} - [String, String]
+      # @return {Array<Object>} - [String, String, Hash]
       def extract_data_from(route)
         defaults = route.defaults.dup
         controller = defaults.delete(:controller)

--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -54,7 +54,8 @@ module Chusaku
       # @return {void}
       def add_info_for(route:, routes:, controller:, action:, defaults:)
         verbs_for(route).each do |verb|
-          routes[controller][action].push(format(route: route, verb: verb, defaults: defaults))
+          routes[controller][action]
+            .push(format(route: route, verb: verb, defaults: defaults))
           routes[controller][action].uniq!
         end
       end

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -72,6 +72,7 @@ class ChusakuTest < Minitest::Test
         class WaterliliesController < ApplicationController
           # @route GET /waterlilies/:id (waterlilies)
           # @route GET /waterlilies/:id (waterlilies2)
+          # @route GET /waterlilies/:id{blue: true} (waterlilies_blue)
           def show; end
 
           # @route GET /one-off

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -72,7 +72,7 @@ class ChusakuTest < Minitest::Test
         class WaterliliesController < ApplicationController
           # @route GET /waterlilies/:id (waterlilies)
           # @route GET /waterlilies/:id (waterlilies2)
-          # @route GET /waterlilies/:id{blue: true} (waterlilies_blue)
+          # @route GET /waterlilies/:id {blue: true} (waterlilies_blue)
           def show; end
 
           # @route GET /one-off

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -74,6 +74,14 @@ module Rails
       routes.push \
         mock_route \
           controller: 'waterlilies',
+          action: 'show',
+          verb: 'GET',
+          path: '/waterlilies/:id(.:format)',
+          name: 'waterlilies_blue',
+          defaults: { blue: true }
+      routes.push \
+        mock_route \
+          controller: 'waterlilies',
           action: 'one_off',
           verb: 'GET',
           path: '/one-off',
@@ -108,9 +116,9 @@ module Rails
     # @param {String} path - Mocked Rails path
     # @param {String} name - Mocked route name
     # @return {Minitest::Mock} - Mocked route
-    def mock_route(controller:, action:, verb:, path:, name:)
+    def mock_route(controller:, action:, verb:, path:, name:, defaults: {})
       route = Minitest::Mock.new
-      route.expect(:defaults, controller: controller, action: action)
+      route.expect(:defaults, controller: controller, action: action, **defaults)
       route.expect(:verb, verb)
       route_path = Minitest::Mock.new
 

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -115,6 +115,7 @@ module Rails
     # @param {String} verb - HTTP verb
     # @param {String} path - Mocked Rails path
     # @param {String} name - Mocked route name
+    # @param {Hash} defaults - Mocked default params
     # @return {Minitest::Mock} - Mocked route
     def mock_route(controller:, action:, verb:, path:, name:, defaults: {})
       route = Minitest::Mock.new

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -8,29 +8,30 @@ class RoutesTest < Minitest::Test
       {
         'api/burritos' => {
           'create' => [
-            { verb: 'POST', path: '/api/burritos', name: 'burritos' }
+            { verb: 'POST', path: '/api/burritos', name: 'burritos', defaults: {} }
           ]
         },
         'api/tacos' => {
           'show' => [
-            { verb: 'GET', path: '/', name: 'root' },
-            { verb: 'GET', path: '/api/tacos/:id', name: 'taco' }
+            { verb: 'GET', path: '/', name: 'root', defaults: {} },
+            { verb: 'GET', path: '/api/tacos/:id', name: 'taco', defaults: {} }
           ],
           'create' => [
-            { verb: 'POST', path: '/api/tacos', name: 'tacos' }
+            { verb: 'POST', path: '/api/tacos', name: 'tacos', defaults: {} }
           ],
           'update' => [
-            { verb: 'PUT', path: '/api/tacos/:id', name: 'taco' },
-            { verb: 'PATCH', path: '/api/tacos/:id', name: 'taco' }
+            { verb: 'PUT', path: '/api/tacos/:id', name: 'taco', defaults: {} },
+            { verb: 'PATCH', path: '/api/tacos/:id', name: 'taco', defaults: {} }
           ]
         },
         'waterlilies' => {
           'show' => [
-            { verb: 'GET', path: '/waterlilies/:id', name: 'waterlilies' },
-            { verb: 'GET', path: '/waterlilies/:id', name: 'waterlilies2' }
+            { verb: 'GET', path: '/waterlilies/:id', name: 'waterlilies', defaults: {} },
+            { verb: 'GET', path: '/waterlilies/:id', name: 'waterlilies2', defaults: {} },
+            { verb: 'GET', path: '/waterlilies/:id', name: 'waterlilies_blue', defaults: { blue: true } }
           ],
           'one_off' => [
-            { verb: 'GET', path: '/one-off', name: nil }
+            { verb: 'GET', path: '/one-off', name: nil, defaults: {} }
           ]
         }
       }


### PR DESCRIPTION
Route may be declared with `defaults: {some: param}`, which is necessary information to understand how it is called in this case.
Some examples (from real codebase, with slightly changed route names for anonymization):

**case 1: "by id" vs "all"**

```ruby
get '/users/:id/events', controller: :users, action: :events
get '/users/all/events', controller: :users, action: :events, defaults: {all: true}
```
Now, controller method events has this annotation:
```ruby
# @route GET /users/:id/events
# @route GET /users/all/events
def events
```
...which requires digging deep in code to understand how in "all" case it would understand it is `all` (or looking into `routes.rb`, which Chusaku helps to avoid). With proposed addon:
```ruby
# @route GET /users/:id/events
# @route GET /users/all/events{all: true}
def events
```

**case 2: this or that**

```ruby
get '/dashboard', controller: :dashboard, action: :index, {context: 'general'}
get '/dashboard/mine', controller: :dashboard, action: :index, {context: 'current_user'}
```

Annotations:
```ruby
# before:
# @route GET /dashboard
# @route GET /dashboard/mine

# after:
# @route GET /dashboard{context: "generic"}
# @route GET /dashboard/mine{context: "current_user"}
```

**case 2: many of them!**

```ruby
REPORTS.each do |name, definition|
  get '/report/monthly', defaults: {name: name, **definition}
end
```

Annotations:
```ruby
# before:
# @route GET /reports/montly
# @route GET /reports/montly
# @route GET /reports/montly
# ...repeat 20 times

# after:
# @route GET /reports/montly{name: "performance"}
# @route GET /reports/montly{name: "money", private: true, group: "weeks"}
# @route GET /reports/montly{name: "messages", group: "days"}
# ...
```

WDYT?..

One concern with this idea is `defaults:` frequently used to pass `defaults: {format: "json"}` or something like that, which current solution renders as any other default variable, but maybe it could be done smarter (by attaching `.json` to path?..)