### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.7'
   spec.add_development_dependency 'rubocop-performance', '~> 1.9'
 
-  spec.add_dependency 'rails', '> 2.0'
+  spec.add_dependency 'railties', '>= 3.0'
 end


### PR DESCRIPTION
this allows for consumers to remove the rails dependency if they only need pieces of rails

This was brought on by the issue here ( https://twitter.com/nateberkopec/status/1374722404228853762 )

And since we are not using activestorage we could simply remove it, however this gem keeps pulling rails back in (when not needed)