### PR TITLE
Add more detailed output with `--verbose` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Chusaku has some flags available for use as well:
 ```
 $ bundle exec chusaku --help
 Usage: chusaku [options]
+        --dry-run                    Run without file modifications
         --exit-with-error-on-annotation
                                      Fail if any file was annotated
-        --dry-run                    Run without file modifications
+        --verbose                    Print all annotations
     -v, --version                    Show Chusaku version number and quit
     -h, --help                       Show this help message and quit
 ```

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -209,12 +209,18 @@ module Chusaku
       @changes.map do |change|
         <<~CHANGE_OUTPUT
           [#{change[:path]}:#{change[:line_number]}]
-          ---OLD
+
+          Before:
+          ```ruby
           #{change[:old_body].chomp}
-          ---NEW
+          ```
+
+          After:
+          ```ruby
           #{change[:new_body].chomp}
+          ```
         CHANGE_OUTPUT
-      end.join
+      end.join("\n")
     end
   end
 end

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -20,7 +20,7 @@ module Chusaku
     def call(flags = {})
       @flags = flags
       @routes = Chusaku::Routes.call
-      @annotated_paths = []
+      @changes = []
       controllers_pattern = 'app/controllers/**/*_controller.rb'
 
       Dir.glob(Rails.root.join(controllers_pattern)).each do |path|
@@ -45,16 +45,44 @@ module Chusaku
     def annotate_file(path:, controller:, actions:)
       parsed_file = Chusaku::Parser.call(path: path, actions: actions)
       parsed_file[:groups].each_cons(2) do |prev, curr|
-        clean_group(prev)
+        record_change(group: prev, type: :clean, path: path)
         next unless curr[:type] == :action
 
         route_data = @routes[controller][curr[:action]]
         next unless route_data.any?
 
-        annotate_group(group: curr, route_data: route_data)
+        record_change(group: curr, type: :annotate, route_data: route_data, path: path)
       end
 
       write_to_file(path: path, parsed_file: parsed_file)
+    end
+
+    # Clean or annotate a group and track the group as changed if applicable.
+    #
+    # @param group [Hash] { type => Symbol, body => String }
+    # @param type [Symbol] [:clean, :annotate]
+    # @param path [String] File path
+    # @param route_data [Array<Hash>] [{
+    #   verb: String,
+    #   path: String,
+    #   name: String }]
+    # @return [void]
+    def record_change(group:, type:, path:, route_data: [])
+      old_body = group[:body]
+
+      case type
+      when :clean
+        clean_group(group)
+      when :annotate
+        annotate_group(group: group, route_data: route_data)
+      end
+      return if old_body == group[:body]
+
+      @changes.push \
+        old_body: old_body,
+        new_body: group[:body],
+        path: path,
+        line_number: group[:line_number]
     end
 
     # Given a parsed group, clean out its contents.
@@ -112,10 +140,9 @@ module Chusaku
     # @return [void]
     def write_to_file(path:, parsed_file:)
       new_content = new_content_for(parsed_file)
-      return unless parsed_file[:content] != new_content
+      return if parsed_file[:content] == new_content
 
       !@flags.include?(:dry) && perform_write(path: path, content: new_content)
-      @annotated_paths.push(path)
     end
 
     # Extracts the new file content for the given parsed file.
@@ -156,7 +183,7 @@ module Chusaku
     def output_results
       puts(output_copy)
       exit_code = 0
-      exit_code = 1 if @annotated_paths.any? && @flags.include?(:error_on_annotation)
+      exit_code = 1 if @changes.any? && @flags.include?(:error_on_annotation)
       exit_code
     end
 
@@ -164,25 +191,30 @@ module Chusaku
     #
     # @return [String] Copy to be outputted to user
     def output_copy
-      return 'Nothing to annotate.' if @annotated_paths.empty?
+      return 'Nothing to annotate.' if @changes.empty?
 
-      annotated_paths = @annotated_paths.join(', ')
-      dry_run = @flags.include?(:dry)
-      error_on_annotation = @flags.include?(:error_on_annotation)
+      copy = changes_copy
+      copy += "\nChusaku has finished running."
+      copy += "\nThis was a dry run so no files were changed." if @flags.include?(:dry)
+      copy += "\nExited with status code 1." if @flags.include?(:error_on_annotation)
+      copy
+    end
 
-      if dry_run && error_on_annotation
-        <<~COPY
-          Annotations missing in the following files: #{annotated_paths}
+    # Returns the copy for recorded changes if `--verbose` flag is passed.
+    #
+    # @return [String] Copy of recorded changes
+    def changes_copy
+      return '' unless @flags.include?(:verbose)
 
-          Run `chusaku` to annotate them. Exiting with status code 1.
-        COPY
-      elsif dry_run
-        "The following files would be annotated without `--dry-run`: #{annotated_paths}"
-      elsif error_on_annotation
-        "Annotated #{annotated_paths}.\n\nExiting with status code 1."
-      else
-        "Annotated #{annotated_paths}."
-      end
+      @changes.map do |change|
+        <<~CHANGE_OUTPUT
+          [#{change[:path]}:#{change[:line_number]}]
+          ---OLD
+          #{change[:old_body].chomp}
+          ---NEW
+          #{change[:new_body].chomp}
+        CHANGE_OUTPUT
+      end.join
     end
   end
 end

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -54,23 +54,11 @@ module Chusaku
     def optparser
       OptionParser.new do |opts|
         opts.banner = 'Usage: chusaku [options]'
-        add_error_on_annotation_flag(opts)
         add_dry_run_flag(opts)
+        add_error_on_annotation_flag(opts)
+        add_verbose_flag(opts)
         add_version_flag(opts)
         add_help_flag(opts)
-      end
-    end
-
-    # Adds `--exit-with-error-on-annotation` flag.
-    #
-    # @param opts [OptionParser] OptionParser instance
-    # @return [void]
-    def add_error_on_annotation_flag(opts)
-      opts.on(
-        '--exit-with-error-on-annotation',
-        'Fail if any file was annotated'
-      ) do
-        @options[:error_on_annotation] = true
       end
     end
 
@@ -79,11 +67,28 @@ module Chusaku
     # @param opts [OptionParser] OptionParser instance
     # @return [void]
     def add_dry_run_flag(opts)
-      opts.on(
-        '--dry-run',
-        'Run without file modifications'
-      ) do
+      opts.on('--dry-run', 'Run without file modifications') do
         @options[:dry] = true
+      end
+    end
+
+    # Adds `--exit-with-error-on-annotation` flag.
+    #
+    # @param opts [OptionParser] OptionParser instance
+    # @return [void]
+    def add_error_on_annotation_flag(opts)
+      opts.on('--exit-with-error-on-annotation', 'Fail if any file was annotated') do
+        @options[:error_on_annotation] = true
+      end
+    end
+
+    # Adds `--verbose` flag.
+    #
+    # @param opts [OptionParser] OptionParser instance
+    # @return [void]
+    def add_verbose_flag(opts)
+      opts.on('--verbose', 'Print all annotations') do
+        @options[:verbose] = true
       end
     end
 
@@ -92,11 +97,7 @@ module Chusaku
     # @param opts [OptionParser] OptionParser instance
     # @return [void]
     def add_version_flag(opts)
-      opts.on(
-        '-v',
-        '--version',
-        'Show Chusaku version number and quit'
-      ) do
+      opts.on('-v', '--version', 'Show Chusaku version number and quit') do
         puts(Chusaku::VERSION)
         raise Finished
       end
@@ -107,11 +108,7 @@ module Chusaku
     # @param opts [OptionParser] OptionParser instance
     # @return [void]
     def add_help_flag(opts)
-      opts.on(
-        '-h',
-        '--help',
-        'Show this help message and quit'
-      ) do
+      opts.on('-h', '--help', 'Show this help message and quit') do
         puts(opts)
         raise Finished
       end

--- a/lib/chusaku/parser.rb
+++ b/lib/chusaku/parser.rb
@@ -13,22 +13,26 @@ module Chusaku
     #       {
     #         type: :code,
     #         body: 'class Foo\n',
-    #         action: nil
+    #         action: nil,
+    #         line_number: 1
     #       },
     #       {
     #         type: :comment,
     #         body: '  # Bar\n  # Baz\n',
-    #         action: nil
+    #         action: nil,
+    #         line_number: 2
     #       },
     #       {
     #         type: :action,
     #         body: '  def action_name; end\n',
-    #         action: 'action_name'
+    #         action: 'action_name',
+    #         line_number: 4
     #       }
     #       {
     #         type: :code,
     #         body: 'end # vanilla is the best flavor\n',
-    #         action: nil
+    #         action: nil,
+    #         line_number: 5
     #       }
     #     ]
     #   }

--- a/lib/chusaku/parser.rb
+++ b/lib/chusaku/parser.rb
@@ -41,7 +41,7 @@ module Chusaku
       group = {}
       content = IO.read(path)
 
-      content.each_line do |line|
+      content.each_line.with_index do |line, index|
         parsed_line = parse_line(line: line, actions: actions)
 
         if group[:type] == parsed_line[:type]
@@ -51,7 +51,7 @@ module Chusaku
           # Now looking at a new group. Push the current group onto the array
           # and start a new one.
           groups.push(group) unless group.empty?
-          group = parsed_line
+          group = parsed_line.merge(line_number: index + 1)
         end
       end
 

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -11,7 +11,7 @@ class ChusakuTest < Minitest::Test
 
     assert_equal(0, exit_code)
     assert_empty(File.written_files)
-    assert_includes(out, 'would be annotated')
+    assert_includes(out, 'This was a dry run so no files were changed.')
   end
 
   def test_exit_with_error_on_annotation_flag
@@ -22,7 +22,7 @@ class ChusakuTest < Minitest::Test
 
     assert_equal(1, exit_code)
     assert_equal(2, File.written_files.count)
-    assert_includes(out, 'status code 1')
+    assert_includes(out, 'Exited with status code 1.')
   end
 
   def test_dry_run_and_exit_with_error_flag
@@ -33,21 +33,40 @@ class ChusakuTest < Minitest::Test
 
     assert_equal(1, exit_code)
     assert_empty(File.written_files)
-    assert_includes(out, 'Annotations missing')
-    assert_includes(out, 'status code 1')
+    assert_includes(out, 'This was a dry run so no files were changed.')
+    assert_includes(out, 'Exited with status code 1.')
+  end
+
+  def test_verbose_flag
+    File.reset_mock
+    exit_code = 0
+
+    out, _err = capture_io { exit_code = Chusaku.call(verbose: true) }
+
+    assert_equal(0, exit_code)
+    assert_includes \
+      out,
+      <<~CHANGES_COPY
+        [test/mock/app/controllers/api/tacos_controller.rb:4]
+        ---OLD
+          def show; end
+        ---NEW
+          # @route GET / (root)
+          # @route GET /api/tacos/:id (taco)
+          def show; end
+      CHANGES_COPY
   end
 
   def test_mock_app
     File.reset_mock
     exit_code = 0
 
-    out, _err = capture_io { exit_code = Chusaku.call }
+    capture_io { exit_code = Chusaku.call }
     files = File.written_files
     base_path = 'test/mock/app/controllers'
 
     assert_equal(0, exit_code)
     assert(2, files.count)
-    assert_includes(out, 'Annotated')
     refute_includes(files, "#{base_path}/api/burritos_controller.rb")
 
     expected =

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -48,12 +48,18 @@ class ChusakuTest < Minitest::Test
       out,
       <<~CHANGES_COPY
         [test/mock/app/controllers/api/tacos_controller.rb:4]
-        ---OLD
+
+        Before:
+        ```ruby
           def show; end
-        ---NEW
+        ```
+
+        After:
+        ```ruby
           # @route GET / (root)
           # @route GET /api/tacos/:id (taco)
           def show; end
+        ```
       CHANGES_COPY
   end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -68,4 +68,14 @@ class Chusaku::CLITest < Minitest::Test
       assert_equal({ error_on_annotation: true }, cli.options)
     end
   end
+
+  def test_verbose_flag
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(['--verbose']))
+      end
+      assert_equal({ verbose: true }, cli.options)
+    end
+  end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -18,6 +18,9 @@ class ParserTest < Minitest::Test
     assert_equal \
       [nil, nil, nil, 'foo', nil],
       (result[:groups].map { |r| r[:action] })
+    assert_equal \
+      [1, 2, 4, 6, 7],
+      (result[:groups].map { |r| r[:line_number] })
   end
 
   def test_empty_file


### PR DESCRIPTION
# Discussion

#24.


# Overview

This PR adds a `--verbose` flag to Chusaku and outputs changes in detail when used with that flag.

Example output:

````
[test/mock/app/controllers/api/burritos_controller.rb:4]

Before:
```ruby
  # @route POST /api/burritos (burritos)
```

After:
```ruby

```

[test/mock/app/controllers/api/burritos_controller.rb:5]

Before:
```ruby
  def create; end
```

After:
```ruby
  # @route POST /api/burritos (burritos)
  def create; end
```

[test/mock/app/controllers/api/tacos_controller.rb:4]

Before:
```ruby
  def show; end
```

After:
```ruby
  # @route GET / (root)
  # @route GET /api/tacos/:id (taco)
  def show; end
```

[test/mock/app/controllers/api/tacos_controller.rb:6]

Before:
```ruby
  # This is an example of generated annotations that come with Rails 6
  # scaffolds. These should be replaced by Chusaku annotations.
  # POST /api/tacos
  # PATCH/PUT /api/tacos/1
```

After:
```ruby
  # This is an example of generated annotations that come with Rails 6
  # scaffolds. These should be replaced by Chusaku annotations.
```

[test/mock/app/controllers/api/tacos_controller.rb:10]

Before:
```ruby
  def create; end
```

After:
```ruby
  # @route POST /api/tacos (tacos)
  def create; end
```

[test/mock/app/controllers/api/tacos_controller.rb:12]

Before:
```ruby
  # Update all the tacos!
  # @route this should be deleted, it's not a valid route.
  # We should not see a duplicate @route in this comment block.
  # @route PUT /api/tacos/:id (taco)
  # But this should remain (@route), because it's just words.
```

After:
```ruby
  # Update all the tacos!
  # We should not see a duplicate @route in this comment block.
  # But this should remain (@route), because it's just words.
```

[test/mock/app/controllers/api/tacos_controller.rb:17]

Before:
```ruby
  def update; end
```

After:
```ruby
  # @route PUT /api/tacos/:id (taco)
  # @route PATCH /api/tacos/:id (taco)
  def update; end
```

[test/mock/app/controllers/api/tacos_controller.rb:19]

Before:
```ruby
  # This route doesn't exist, so it should be deleted.
  # @route DELETE /api/tacos/:id
```

After:
```ruby
  # This route doesn't exist, so it should be deleted.
```

[test/mock/app/controllers/waterlilies_controller.rb:4]

Before:
```ruby
  def show; end
```

After:
```ruby
  # @route GET /waterlilies/:id (waterlilies)
  # @route GET /waterlilies/:id (waterlilies2)
  # @route GET /waterlilies/:id {blue: true} (waterlilies_blue)
  def show; end
```

[test/mock/app/controllers/waterlilies_controller.rb:6]

Before:
```ruby
  def one_off; end
```

After:
```ruby
  # @route GET /one-off
  def one_off; end
```

Chusaku has finished running.
````