### PR TITLE
Fix no "nothing to annotate" bug

### DIFF
--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -19,6 +19,7 @@ module Chusaku
       @flags = flags
       @routes = Chusaku::Routes.call
       @changes = []
+      @changed_files = []
       controllers_pattern = "app/controllers/**/*_controller.rb"
 
       Dir.glob(Rails.root.join(controllers_pattern)).each do |path|
@@ -141,6 +142,7 @@ module Chusaku
       return if parsed_file[:content] == new_content
 
       !@flags.include?(:dry) && perform_write(path: path, content: new_content)
+      @changed_files.push(path)
     end
 
     # Extracts the new file content for the given parsed file.
@@ -181,7 +183,7 @@ module Chusaku
     def output_results
       puts(output_copy)
       exit_code = 0
-      exit_code = 1 if @changes.any? && @flags.include?(:error_on_annotation)
+      exit_code = 1 if @changed_files.any? && @flags.include?(:error_on_annotation)
       exit_code
     end
 
@@ -189,7 +191,7 @@ module Chusaku
     #
     # @return [String] Copy to be outputted to user
     def output_copy
-      return "Nothing to annotate." if @changes.empty?
+      return "Nothing to annotate." if @changed_files.empty?
 
       copy = changes_copy
       copy += "\nChusaku has finished running."

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -2,7 +2,6 @@ require_relative "test_helper"
 
 class ChusakuTest < Minitest::Test
   def test_dry_run_flag
-    File.reset_mock
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(dry: true) }
@@ -13,7 +12,6 @@ class ChusakuTest < Minitest::Test
   end
 
   def test_exit_with_error_on_annotation_flag
-    File.reset_mock
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(error_on_annotation: true) }
@@ -24,7 +22,6 @@ class ChusakuTest < Minitest::Test
   end
 
   def test_dry_run_and_exit_with_error_flag
-    File.reset_mock
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(dry: true, error_on_annotation: true) }
@@ -36,7 +33,6 @@ class ChusakuTest < Minitest::Test
   end
 
   def test_verbose_flag
-    File.reset_mock
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(verbose: true) }
@@ -62,7 +58,6 @@ class ChusakuTest < Minitest::Test
   end
 
   def test_mock_app
-    File.reset_mock
     exit_code = 0
 
     capture_io { exit_code = Chusaku.call }
@@ -124,5 +119,16 @@ class ChusakuTest < Minitest::Test
         end
       HEREDOC
     assert_equal(expected, files["#{base_path}/waterlilies_controller.rb"])
+  end
+
+  def test_mock_app_with_no_pending_annotations
+    Rails.set_route_allowlist(["api/burritos#create"])
+    exit_code = 0
+
+    out, _err = capture_io { exit_code = Chusaku.call }
+
+    assert_equal(0, exit_code)
+    assert_empty(File.written_files)
+    assert_equal("Nothing to annotate.\n", out)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,16 @@ require_relative "mock/rails"
 require_relative "mock/file"
 require "chusaku/cli"
 require "minitest/autorun"
+
+module ChusakuTestPlugin
+  def before_setup
+    super
+
+    File.reset_mock
+    Rails.set_route_allowlist([])
+  end
+end
+
+class Minitest::Test
+  include ChusakuTestPlugin
+end


### PR DESCRIPTION
# Issue

Fixes #27.


# Overview

There was a bug in which `Nothing to annotate.` was not in the output of Chusaku runs when it should have been. This was due to #25 where more detailed changes started getting tracked in `chusaku.rb`.

This PR adds a test for and fixes this bug. 