### PR TITLE
Fix broken blog post link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This example config only runs Chusaku if `routes.rb` was modified.
 ## Development
 
 Read the blog post explaining how the gem works at a high level:
-https://nshki.com/chusaku-a-controller-annotation-gem/.
+https://nshki.com/chusaku-a-controller-annotation-gem.
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run
 `bundle exec rake test` to run the tests. You can also run `bin/console` for an

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -128,7 +128,7 @@ module Rails
       return if @@route_allowlist.any? && @@route_allowlist.index("#{controller}##{action}").nil?
 
       route = Minitest::Mock.new
-      route.expect(:defaults, controller: controller, action: action, **defaults)
+      route.expect(:defaults, {controller: controller, action: action, **defaults})
       route.expect(:verb, verb)
       route_path = Minitest::Mock.new
 


### PR DESCRIPTION
# Overview

As the title states, this updates the README so that the link to the blog post isn't broken. I suspect this link broke/unbroke a couple times as I transitioned to/from using Remix and Jekyll as the underlying tech powering my blog.