### PR TITLE
fix: missing route names

### DIFF
--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -17,7 +17,7 @@ class ChusakuTest < Minitest::Test
     out, _err = capture_io { exit_code = Chusaku.call(error_on_annotation: true) }
 
     assert_equal(1, exit_code)
-    assert_equal(2, File.written_files.count)
+    assert_equal(3, File.written_files.count)
     assert_includes(out, "Exited with status code 1.")
   end
 
@@ -67,6 +67,19 @@ class ChusakuTest < Minitest::Test
     assert_equal(0, exit_code)
     assert(2, files.count)
     refute_includes(files, "#{base_path}/api/burritos_controller.rb")
+
+    expected =
+      <<~HEREDOC
+        class CakesController < ApplicationController
+          # This route's GET action should be named the same as its PUT action,
+          # even though only the PUT action is named.
+          # @route GET /api/cakes/inherit (inherit)
+          # @route PUT /api/cakes/inherit (inherit)
+          def inherit
+          end
+        end
+      HEREDOC
+    assert_equal(expected, files["#{base_path}/api/cakes_controller.rb"])
 
     expected =
       <<~HEREDOC

--- a/test/mock/app/controllers/api/cakes_controller.rb
+++ b/test/mock/app/controllers/api/cakes_controller.rb
@@ -1,0 +1,6 @@
+class CakesController < ApplicationController
+  # This route's GET action should be named the same as its PUT action,
+  # even though only the PUT action is named.
+  def inherit
+  end
+end

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -22,6 +22,20 @@ module Rails
           name: "burritos"
       routes.push \
         mock_route \
+          controller: "api/cakes",
+          action: "inherit",
+          verb: "GET",
+          path: "/api/cakes/inherit(.:format)",
+          name: nil
+      routes.push \
+        mock_route \
+          controller: "api/cakes",
+          action: "inherit",
+          verb: "PUT",
+          path: "/api/cakes/inherit(.:format)",
+          name: "inherit"
+      routes.push \
+        mock_route \
           controller: "api/tacos",
           action: "show",
           verb: "GET",

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -9,6 +9,12 @@ class RoutesTest < Minitest::Test
             {verb: "POST", path: "/api/burritos", name: "burritos", defaults: {}}
           ]
         },
+        "api/cakes" => {
+          "inherit" => [
+            {verb: "GET", path: "/api/cakes/inherit", name: "inherit", defaults: {}},
+            {verb: "PUT", path: "/api/cakes/inherit", name: "inherit", defaults: {}}
+          ]
+        },
         "api/tacos" => {
           "show" => [
             {verb: "GET", path: "/", name: "root", defaults: {}},


### PR DESCRIPTION
# Issue

Fixes #34.

# Overview

This PR fixes an issue where Chusaku doesn't annotate a name for a route even when its path has one.