### PR TITLE
Also look for controllers outside /app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Chusaku has some flags available for use as well:
 ```
 $ bundle exec chusaku --help
 Usage: chusaku [options]
-        --dry-run                    Run without file modifications
-        --exit-with-error-on-annotation
-                                     Fail if any file was annotated
-        --verbose                    Print all annotations
-    -v, --version                    Show Chusaku version number and quit
-    -h, --help                       Show this help message and quit
+        --dry-run                       Run without file modifications
+        --exit-with-error-on-annotation Fail if any file was annotated
+    -c, --controllers-pattern=GLOB      Specify alternative controller files glob pattern
+        --verbose                       Print all annotations
+    -v, --version                       Show Chusaku version number and quit
+    -h, --help                          Show this help message and quit
+
 ```
 
 

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -20,7 +20,7 @@ module Chusaku
       @routes = Chusaku::Routes.call
       @changes = []
       @changed_files = []
-      controllers_pattern = "app/controllers/**/*_controller.rb"
+      controllers_pattern = @flags[:controllers_pattern] || "app/controllers/**/*_controller.rb"
 
       Dir.glob(Rails.root.join(controllers_pattern)).each do |path|
         controller = %r{controllers/(.*)_controller\.rb}.match(path)[1]

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -55,6 +55,7 @@ module Chusaku
         opts.set_summary_width(35)
         add_dry_run_flag(opts)
         add_error_on_annotation_flag(opts)
+        add_controllers_pattern_flag(opts)
         add_verbose_flag(opts)
         add_version_flag(opts)
         add_help_flag(opts)
@@ -78,6 +79,16 @@ module Chusaku
     def add_error_on_annotation_flag(opts)
       opts.on("--exit-with-error-on-annotation", "Fail if any file was annotated") do
         @options[:error_on_annotation] = true
+      end
+    end
+
+    # Adds `--controllers-pattern` flag.
+    #
+    # @param opts [OptionParser] OptionParser instance
+    # @return [void]
+    def add_controllers_pattern_flag(opts)
+      opts.on("-c", "--controllers-pattern", "=GLOB", "Specify alternative controller files glob pattern") do |value|
+        @options[:controllers_pattern] = value
       end
     end
 

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -52,6 +52,7 @@ module Chusaku
     def optparser
       OptionParser.new do |opts|
         opts.banner = "Usage: chusaku [options]"
+        opts.set_summary_width(35)
         add_dry_run_flag(opts)
         add_error_on_annotation_flag(opts)
         add_verbose_flag(opts)

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -144,4 +144,15 @@ class ChusakuTest < Minitest::Test
     assert_empty(File.written_files)
     assert_equal("Nothing to annotate.\n", out)
   end
+
+  def test_mock_app_with_non_matching_controllers_pattern
+    exit_code = 0
+
+    args = {controllers_pattern: "**/nomatch/*_controller.rb"}
+    out, = capture_io { exit_code = Chusaku.call(args) }
+
+    assert_equal(0, exit_code)
+    assert_empty(File.written_files)
+    assert_equal("Nothing to annotate.\n", out)
+  end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -76,4 +76,24 @@ class Chusaku::CLITest < Minitest::Test
       assert_equal({verbose: true}, cli.options)
     end
   end
+
+  def test_controllers_pattern_flag
+    # --controllers-pattern
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["--controllers-pattern=**/controllers/**/*_controller.rb"]))
+      end
+      assert_equal({controllers_pattern: "**/controllers/**/*_controller.rb"}, cli.options)
+    end
+
+    # -c
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["-c", "**/controllers/**/*_controller.rb"]))
+      end
+      assert_equal({controllers_pattern: "**/controllers/**/*_controller.rb"}, cli.options)
+    end
+  end
 end

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -4,6 +4,9 @@
 # for each version.
 #
 # The mocks used should reflect the files located in `test/mock/app/`.
+
+require "pathname"
+
 module Rails
   class << self
     # Lets us call `Rails.application.routes.routes` without a skeleton Rails
@@ -116,14 +119,9 @@ module Rails
 
     # Lets us call `Rails.root` without a skeleton Rails app.
     #
-    # @return [Minitest::Mock] Mocked `Rails.root`
+    # @return [Pathname] Pathname object like Rails.root
     def root
-      rails_root = Minitest::Mock.new
-      rails_root.expect \
-        :join,
-        "test/mock/app/controllers/**/*_controller.rb",
-        [String]
-      rails_root
+      Pathname.new("test/mock")
     end
 
     private


### PR DESCRIPTION
Hi! Thank you for this gem!

We're using [packs-rails](https://github.com/rubyatscale/packs-rails) in our rails app, which means we've got controllers outside the `/app` directory.
If you think it makes sense, could you consider supporting this use-case? I found this way to be the most minimal change required to support it.

Thank you!