### PR TITLE
fix typo assert

### DIFF
--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -65,7 +65,7 @@ class ChusakuTest < Minitest::Test
     base_path = "test/mock/app/controllers"
 
     assert_equal(0, exit_code)
-    assert(2, files.count)
+    assert_equal(3, files.count)
     refute_includes(files, "#{base_path}/api/burritos_controller.rb")
 
     expected =


### PR DESCRIPTION
Fix a typo in an `assert`. More details: https://github.com/nshki/chusaku/pull/37#issuecomment-1704390602