### PR TITLE
feat: add Rake task

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /spec/reports/
 /tmp/
 
+.ruby-version
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this line to your Rails application's Gemfile:
 
 ```ruby
 group :development do
-  gem "chusaku"
+  gem "chusaku", require: false
 end
 ```
 
@@ -64,6 +64,7 @@ Usage: chusaku [options]
 If you'd like to use Chusaku as a Rake task, add the following line to your `Rakefile`:
 
 ```ruby
+require "chusaku"
 Chusaku.load_tasks
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,14 @@ Add this line to your Rails application's Gemfile:
 
 ```ruby
 group :development do
-  # ...
-  gem "chusaku", require: false
-  # ...
+  gem "chusaku"
 end
 ```
 
 And then execute:
 
-```
-$ bundle install
+```sh
+bundle install
 ```
 
 
@@ -43,8 +41,8 @@ $ bundle install
 
 From the root of your Rails application, run:
 
-```
-$ bundle exec chusaku
+```sh
+bundle exec chusaku
 ```
 
 Chusaku has some flags available for use as well:
@@ -61,17 +59,31 @@ Usage: chusaku [options]
 
 ```
 
+### Rake usage
+
+If you'd like to use Chusaku as a Rake task, add the following line to your `Rakefile`:
+
+```ruby
+Chusaku.load_tasks
+```
+
+This will then allow you to call:
+
+```sh
+bin/rake chusaku
+```
+
+To pass flags, pass them like you would from the CLI executable:
+
+```sh
+bin/rake chusaku -- --dry-run --exit-with-error-on-annotation
+```
+
 
 ## Development
 
-Read the blog post explaining how the gem works at a high level:
-https://nshki.com/chusaku-a-controller-annotation-gem.
+Read the blog post explaining how the gem works at a high level: https://nshki.com/chusaku-a-controller-annotation-gem.
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`bundle exec rake test` to run the tests. You can also run `bin/console` for an
-interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To release a new version, update the version number in `version.rb`, and then
-run `bundle exec rake release`, which will create a git tag for the version,
-git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -33,6 +33,15 @@ module Chusaku
       output_results
     end
 
+    # Load Rake tasks for Chusaku. Should be called in your project's `Rakefile`.
+    #
+    # @return [void]
+    def load_tasks
+      Dir[File.join(File.dirname(__FILE__), "tasks", "**/*.rake")].each do |task|
+        load(task)
+      end
+    end
+
     private
 
     # Adds annotations to the given file.

--- a/lib/tasks/chusaku.rake
+++ b/lib/tasks/chusaku.rake
@@ -1,0 +1,8 @@
+chusaku_lib = File.expand_path(File.dirname(__FILE__, 2))
+
+desc "Add route annotations to your Rails actions"
+task chusaku: :environment do
+  require "#{chusaku_lib}/chusaku/cli"
+
+  Chusaku::CLI.new.call(ARGV[2...])
+end

--- a/lib/tasks/chusaku.rake
+++ b/lib/tasks/chusaku.rake
@@ -4,5 +4,5 @@ desc "Add route annotations to your Rails actions"
 task chusaku: :environment do
   require "#{chusaku_lib}/chusaku/cli"
 
-  Chusaku::CLI.new.call(ARGV[2...])
+  Chusaku::CLI.new.call(ARGV[2...] || [])
 end


### PR DESCRIPTION
# Issue

Closes #40.

# Overview

As the title states, this PR adds a Rake task for Chusaku. This allows users to use a Rake task to execute Chusaku in addition to the executable it ships with like such:

```sh
bin/rake chusaku -- --dry-run
```

Loading the gem's Rake tasks is a matter of adding a one-liner to a project's `Rakefile`:

```ruby
Chusaku.load_tasks
```

Users will need to update their `Gemfile` such that Chusaku isn't being required with the `require: false` flag:

```ruby
# BAD
gem "chusaku", require: false

# GOOD
gem "chusaku"
```