### PR TITLE
fix: improve cli output

### DIFF
--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -200,10 +200,10 @@ module Chusaku
     #
     # @return [String] Copy to be outputted to user
     def output_copy
-      return "Nothing to annotate." if @changed_files.empty?
+      return "Controller files unchanged." if @changed_files.empty?
 
       copy = changes_copy
-      copy += "\nChusaku has finished running."
+      copy += "Chusaku has finished running."
       copy += "\nThis was a dry run so no files were changed." if @flags.include?(:dry)
       copy += "\nExited with status code 1." if @flags.include?(:error_on_annotation)
       copy
@@ -229,7 +229,7 @@ module Chusaku
           #{change[:new_body].chomp}
           ```
         CHANGE_OUTPUT
-      end.join("\n")
+      end.join("\n") + "\n"
     end
   end
 end

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -142,7 +142,7 @@ class ChusakuTest < Minitest::Test
 
     assert_equal(0, exit_code)
     assert_empty(File.written_files)
-    assert_equal("Nothing to annotate.\n", out)
+    assert_equal("Controller files unchanged.\n", out)
   end
 
   def test_mock_app_with_non_matching_controllers_pattern
@@ -153,6 +153,6 @@ class ChusakuTest < Minitest::Test
 
     assert_equal(0, exit_code)
     assert_empty(File.written_files)
-    assert_equal("Nothing to annotate.\n", out)
+    assert_equal("Controller files unchanged.\n", out)
   end
 end


### PR DESCRIPTION
Before:

```
❯ bundle exec rake dev:annotate

Chusaku has finished running.
Model files unchanged.

❯ bundle exec rake dev:annotate
Nothing to annotate.
Model files unchanged.
```

After:

```
❯ bundle exec rake dev:annotate
Chusaku has finished running.
Model files unchanged.

❯ bundle exec rake dev:annotate
Controller files unchanged.
Model files unchanged.
```

I've also preserved the newline before the final output line if `--verbose` is passed.

Resolves #42