### PR TITLE
fix: unnecessary verbose output

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,9 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.0
+          ruby-version: 3.3
           bundler-cache: true
       - name: Run Standard
         run: bundle exec standardrb --fail-level A

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ Usage: chusaku [options]
         --dry-run                       Run without file modifications
         --exit-with-error-on-annotation Fail if any file was annotated
     -c, --controllers-pattern=GLOB      Specify alternative controller files glob pattern
-        --verbose                       Print all annotations
+        --verbose                       Print all annotated files
     -v, --version                       Show Chusaku version number and quit
     -h, --help                          Show this help message and quit
-
 ```
 
 ### Rake usage

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -97,7 +97,7 @@ module Chusaku
     # @param opts [OptionParser] OptionParser instance
     # @return [void]
     def add_verbose_flag(opts)
-      opts.on("--verbose", "Print all annotations") do
+      opts.on("--verbose", "Print all annotated files") do
         @options[:verbose] = true
       end
     end

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -38,23 +38,10 @@ class ChusakuTest < Minitest::Test
     out, _err = capture_io { exit_code = Chusaku.call(verbose: true) }
 
     assert_equal(0, exit_code)
-    assert_includes \
-      out,
-      <<~CHANGES_COPY
-        [test/mock/app/controllers/api/tacos_controller.rb:2]
-
-        Before:
-        ```ruby
-          def show
-        ```
-
-        After:
-        ```ruby
-          # @route GET / (root)
-          # @route GET /api/tacos/:id (taco)
-          def show
-        ```
-      CHANGES_COPY
+    refute_includes(out, "Annotated test/mock/app/controllers/api/burritos_controller.rb")
+    assert_includes(out, "Annotated test/mock/app/controllers/api/cakes_controller.rb")
+    assert_includes(out, "Annotated test/mock/app/controllers/api/tacos_controller.rb")
+    assert_includes(out, "Annotated test/mock/app/controllers/waterlilies_controller.rb")
   end
 
   def test_mock_app


### PR DESCRIPTION
# Issue

Closes #43.

# Overview

This PR changes/fixes the behavior of `--verbose` such that instead of printing out all changes on the given run, it will list out all changed files.