### PR TITLE
Annotate controllers in Rails engines and packs

### DIFF
--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -41,7 +41,8 @@ module Chusaku
     # @raise [Chusaku::CLI::NotARailsProject] Exception if not Rails project
     # @return [void]
     def check_for_rails_project
-      has_controllers = File.directory?("./app/controllers")
+      controllers_pattern = options[:controllers_pattern] || DEFAULT_CONTROLLERS_PATTERN
+      has_controllers = Dir.glob(Rails.root.join(controllers_pattern)).present?
       has_rakefile = File.exist?("./Rakefile")
       raise NotARailsProject unless has_controllers && has_rakefile
     end

--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -27,7 +27,19 @@ module Chusaku
       def call
         routes = {}
 
-        Rails.application.routes.routes.each do |route|
+        populate_routes(Rails.application, routes)
+        backfill_routes(routes)
+      end
+
+      private
+
+      def populate_routes(app, routes)
+        app.routes.routes.each do |route|
+          if route.app.engine?
+            populate_routes(route.app.app, routes)
+            next
+          end
+
           controller, action, defaults = extract_data_from(route)
           routes[controller] ||= {}
           routes[controller][action] ||= []
@@ -39,11 +51,7 @@ module Chusaku
             action: action,
             defaults: defaults
         end
-
-        backfill_routes(routes)
       end
-
-      private
 
       # Adds formatted route info for the given param combination.
       #


### PR DESCRIPTION
_This is a draft. I still have to get the tests updated and write more tests, but I wanted to get some feedback before doing so._

I approached this in a different way from the current implementation.

1. It starts similarly by gathering all the routes, to which I added following routes of any mounted engines.
2. Then instead of iterating through the controllers provided by the controller pattern, I iterated through the routes and then loaded the corresponding controller class.
3. From there I got the source location of controller, and added the annotations but only if the source location matched the controller pattern.

It's possible with Zeitwerk (and probably other mechanisms) for the controller name and path to not line up exactly, so with this approach you don't need to make any assumptions.

Please let me know what you think and if it looks good, I can add and update the tests.

Fixes #47 