### PR TITLE
feat: add `--exclusion-pattern` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Usage: chusaku [options]
         --dry-run                       Run without file modifications
         --exit-with-error-on-annotation Fail if any file was annotated
     -c, --controllers-pattern=GLOB      Specify alternative controller files glob pattern
+    -e, --exclusion-pattern=GLOB        Specify controller files exclusion glob pattern
         --verbose                       Print all annotated files
     -v, --version                       Show Chusaku version number and quit
     -h, --help                          Show this help message and quit

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -1,3 +1,4 @@
+require "rake"
 require "chusaku/version"
 require "chusaku/parser"
 require "chusaku/routes"
@@ -5,6 +6,7 @@ require "chusaku/routes"
 # Handles core functionality of annotating projects.
 module Chusaku
   DEFAULT_CONTROLLERS_PATTERN = "**/*_controller.rb".freeze
+  DEFAULT_EXCLUSION_PATTERN = "vendor/**/*_controller.rb".freeze
 
   class << self
     # The main method to run Chusaku. Annotate all actions in a Rails project as
@@ -22,7 +24,10 @@ module Chusaku
       @routes = Chusaku::Routes.call
       @changed_files = []
       controllers_pattern = @flags[:controllers_pattern] || DEFAULT_CONTROLLERS_PATTERN
-      controllers_paths = Dir.glob(Rails.root.join(controllers_pattern))
+      exclusion_pattern = @flags[:exclusion_pattern] || DEFAULT_EXCLUSION_PATTERN
+      controllers_paths = FileList
+        .new(Rails.root.join(controllers_pattern))
+        .exclude(Rails.root.join(exclusion_pattern))
 
       @routes.each do |controller, actions|
         next unless controller

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -42,7 +42,7 @@ module Chusaku
     # @return [void]
     def check_for_rails_project
       controllers_pattern = options[:controllers_pattern] || DEFAULT_CONTROLLERS_PATTERN
-      has_controllers = !Dir.glob(Rails.root.join(controllers_pattern)).empty?
+      has_controllers = FileList.new(Rails.root.join(controllers_pattern)).any?
       has_rakefile = File.exist?("./Rakefile")
       raise NotARailsProject unless has_controllers && has_rakefile
     end
@@ -57,6 +57,7 @@ module Chusaku
         add_dry_run_flag(opts)
         add_error_on_annotation_flag(opts)
         add_controllers_pattern_flag(opts)
+        add_exclusion_pattern_flag(opts)
         add_verbose_flag(opts)
         add_version_flag(opts)
         add_help_flag(opts)
@@ -90,6 +91,16 @@ module Chusaku
     def add_controllers_pattern_flag(opts)
       opts.on("-c", "--controllers-pattern", "=GLOB", "Specify alternative controller files glob pattern") do |value|
         @options[:controllers_pattern] = value
+      end
+    end
+
+    # Adds `--exclusion-pattern` flag.
+    #
+    # @param opts [OptionParser] OptionParser instance
+    # @return [void]
+    def add_exclusion_pattern_flag(opts)
+      opts.on("-e", "--exclusion-pattern", "=GLOB", "Specify controller files exclusion glob pattern") do |value|
+        @options[:exclusion_pattern] = value
       end
     end
 

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -157,4 +157,15 @@ class ChusakuTest < Minitest::Test
     assert_empty(File.written_files)
     assert_equal("Controller files unchanged.\n", out)
   end
+
+  def test_mock_app_with_custom_exclusion_pattern
+    exit_code = 0
+
+    args = {exclusion_pattern: "**/cakes_controller.rb"}
+    out, = capture_io { exit_code = Chusaku.call(args) }
+
+    assert_equal(0, exit_code)
+    assert_equal(3, File.written_files.count)
+    assert_equal("Chusaku has finished running.\n", out)
+  end
 end


### PR DESCRIPTION
# Issue

Closes #53.

# Overview

This PR introduces a new `--exclusion-pattern` flag to enable users to customize the controller exclusion glob. By default, `--exclusion-pattern` will ignore all `*_controller.rb` files present in the top-level `vendor/` directory.