### PR TITLE
test: use Minitest spec style

### DIFF
--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
-class ChusakuTest < Minitest::Test
-  def test_dry_run_flag
+describe "Chusaku" do
+  it "implements a `dry` option" do
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(dry: true) }
@@ -11,7 +11,7 @@ class ChusakuTest < Minitest::Test
     assert_includes(out, "This was a dry run so no files were changed.")
   end
 
-  def test_exit_with_error_on_annotation_flag
+  it "implements an `error_on_annotation` option" do
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(error_on_annotation: true) }
@@ -21,7 +21,7 @@ class ChusakuTest < Minitest::Test
     assert_includes(out, "Exited with status code 1.")
   end
 
-  def test_dry_run_and_exit_with_error_flag
+  it "can combine the `dry` and `error_on_annotation` options" do
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(dry: true, error_on_annotation: true) }
@@ -32,7 +32,7 @@ class ChusakuTest < Minitest::Test
     assert_includes(out, "Exited with status code 1.")
   end
 
-  def test_verbose_flag
+  it "implements a `verbose` option" do
     exit_code = 0
 
     out, _err = capture_io { exit_code = Chusaku.call(verbose: true) }
@@ -44,7 +44,7 @@ class ChusakuTest < Minitest::Test
     assert_includes(out, "Annotated #{Rails.root}/app/controllers/waterlilies_controller.rb")
   end
 
-  def test_mock_app
+  it "executes properly for the mock app" do
     exit_code = 0
 
     capture_io { exit_code = Chusaku.call }
@@ -136,7 +136,7 @@ class ChusakuTest < Minitest::Test
     assert_equal(expected, files["#{engine_path}/cars_controller.rb"])
   end
 
-  def test_mock_app_with_no_pending_annotations
+  it "outputs properly if there are no changes" do
     Rails.set_route_allowlist(["api/burritos#create"])
     exit_code = 0
 
@@ -147,7 +147,7 @@ class ChusakuTest < Minitest::Test
     assert_equal("Controller files unchanged.\n", out)
   end
 
-  def test_mock_app_with_non_matching_controllers_pattern
+  it "doesn't detect any changes if a custom `controllers_pattern` matches nothing" do
     exit_code = 0
 
     args = {controllers_pattern: "**/nomatch/*_controller.rb"}
@@ -158,7 +158,7 @@ class ChusakuTest < Minitest::Test
     assert_equal("Controller files unchanged.\n", out)
   end
 
-  def test_mock_app_with_custom_exclusion_pattern
+  it "annotates the correct number of files with a custom `exclusion_pattern`" do
     exit_code = 0
 
     args = {exclusion_pattern: "**/cakes_controller.rb"}

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
-class Chusaku::CLITest < Minitest::Test
-  def test_help_flag
+describe "Chusaku::CLI" do
+  it "implements a help flag" do
     # -h
     out, = capture_io do
       assert_equal(0, Chusaku::CLI.new.call(["-h"]))
@@ -15,14 +15,14 @@ class Chusaku::CLITest < Minitest::Test
     assert_match(/Show this help message and quit/, out)
   end
 
-  def test_version_flag
+  it "implements a version flag" do
     out, = capture_io do
       assert_equal(0, Chusaku::CLI.new.call(["-v"]))
     end
     assert_match(/\d+\.\d+\.\d+/, out)
   end
 
-  def test_exit_flag_precedence
+  it "handles -v and -h flags in any order" do
     # Passing -v before -h executes -v and exits.
     out, = capture_io do
       assert_equal(0, Chusaku::CLI.new.call(["-v", "-h"]))
@@ -38,7 +38,7 @@ class Chusaku::CLITest < Minitest::Test
     refute_match(/\d+\.\d+\.\d+/, out)
   end
 
-  def test_project_detection
+  it "detects Rails projects" do
     _, err = capture_io do
       assert_equal(1, Chusaku::CLI.new.call(["-c", "**/*_not_controller.rb"]))
     end
@@ -47,7 +47,7 @@ class Chusaku::CLITest < Minitest::Test
     ERR
   end
 
-  def test_dry_flag
+  it "implements a dry run flag" do
     cli = Chusaku::CLI.new
     cli.stub(:check_for_rails_project, nil) do
       capture_io do
@@ -57,7 +57,7 @@ class Chusaku::CLITest < Minitest::Test
     end
   end
 
-  def test_exit_with_error_on_annotation_flag
+  it "implements an exit-on-error flag" do
     cli = Chusaku::CLI.new
     cli.stub(:check_for_rails_project, nil) do
       capture_io do
@@ -67,7 +67,7 @@ class Chusaku::CLITest < Minitest::Test
     end
   end
 
-  def test_verbose_flag
+  it "implements a verbose flag" do
     cli = Chusaku::CLI.new
     cli.stub(:check_for_rails_project, nil) do
       capture_io do
@@ -77,7 +77,7 @@ class Chusaku::CLITest < Minitest::Test
     end
   end
 
-  def test_controllers_pattern_flag
+  it "implements a controllers pattern flag" do
     # --controllers-pattern
     cli = Chusaku::CLI.new
     cli.stub(:check_for_rails_project, nil) do
@@ -94,6 +94,26 @@ class Chusaku::CLITest < Minitest::Test
         assert_equal(0, cli.call(["-c", "**/controllers/**/*_controller.rb"]))
       end
       assert_equal({controllers_pattern: "**/controllers/**/*_controller.rb"}, cli.options)
+    end
+  end
+
+  it "implements an exclusion pattern flag" do
+    # --exclusion-pattern
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["--exclusion-pattern=**/*_not_controller.rb"]))
+      end
+      assert_equal({exclusion_pattern: "**/*_not_controller.rb"}, cli.options)
+    end
+
+    # -e
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["-e", "**/*_not_controller.rb"]))
+      end
+      assert_equal({exclusion_pattern: "**/*_not_controller.rb"}, cli.options)
     end
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
-class ParserTest < Minitest::Test
-  def test_example_file
+describe "Chusaku::Parser" do
+  it "parses example file properly" do
     result = Chusaku::Parser.call \
       path: "#{__dir__}/mock/examples/example.rb",
       actions: %w[foo]
@@ -21,7 +21,7 @@ class ParserTest < Minitest::Test
       (result[:groups].map { |r| r[:line_number] })
   end
 
-  def test_empty_file
+  it "parses empty file properly" do
     expected = [{}]
 
     result = Chusaku::Parser.call \
@@ -31,7 +31,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result[:groups])
   end
 
-  def test_comment
+  it "parses comments properly" do
     expected = {type: :comment, body: "# foobar", action: nil}
     line = "# foobar"
 
@@ -40,7 +40,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_comment_with_spaces
+  it "parses comments with spaces properly" do
     expected = {type: :comment, body: "  # foobar  ", action: nil}
     line = "  # foobar  "
 
@@ -49,7 +49,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_comment_with_tabs
+  it "parses comments with tabs properly" do
     expected = {type: :comment, body: "\t# foobar\t", action: nil}
     line = "\t# foobar\t"
 
@@ -58,7 +58,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_comment_with_spaces_and_tabs
+  it "parses comments with spaces and tabs properly" do
     expected = {type: :comment, body: "  \t# foobar\t  ", action: nil}
     line = "  \t# foobar\t  "
 
@@ -67,7 +67,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_action
+  it "parses controller actions properly" do
     expected = {type: :action, body: "def foo", action: "foo"}
     line = "def foo"
 
@@ -76,7 +76,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_action_with_spaces
+  it "parses controller actions with spaces properly" do
     expected = {type: :action, body: "  def bar  ", action: "bar"}
     line = "  def bar  "
 
@@ -85,7 +85,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_action_with_tabs
+  it "parses controller actions with tabs properly" do
     expected = {type: :action, body: "\tdef foo\t", action: "foo"}
     line = "\tdef foo\t"
 
@@ -94,7 +94,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_action_with_comment
+  it "parses controller actions with comments properly" do
     expected = {type: :action, body: "def bar # comment", action: "bar"}
     line = "def bar # comment"
 
@@ -103,7 +103,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_non_action_method
+  it "parses regular methods properly" do
     expected = {type: :code, body: "def carrot", action: nil}
     line = "def carrot"
 
@@ -112,7 +112,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_code
+  it "parses code blocks properly" do
     expected = {type: :code, body: 'puts "hello world!"', action: nil}
     line = 'puts "hello world!"'
 
@@ -121,7 +121,7 @@ class ParserTest < Minitest::Test
     assert_equal(expected, result)
   end
 
-  def test_code_with_comment
+  it "parses code blocks with comments" do
     expected = {type: :code, body: 'puts "hello world!" # hey', action: nil}
     line = 'puts "hello world!" # hey'
 

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
-class RoutesTest < Minitest::Test
-  def test_mock_rails
+describe "Chusaku::Routes" do
+  it "parses routes correctly" do
     expected =
       {
         "api/burritos" => {


### PR DESCRIPTION
# Overview

This refactors the test suite to use [Minitest's spec styles](https://github.com/minitest/minitest?tab=readme-ov-file#specs-) instead of the traditional [unit test styles](https://github.com/minitest/minitest?tab=readme-ov-file#unit-tests-). This doesn't change the gem's functionality at all, it only updates the test suite for, in my opinion, better readability.