### PR TITLE
fix: inherited actions

### DIFF
--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -192,10 +192,10 @@ module Chusaku
         controller = defaults.delete(:controller)
         action = defaults.delete(:action)
 
-        controller_class = "#{controller.underscore.camelize}Controller".constantize
-        action_method_name = action.to_sym
+        controller_class = controller ? "#{controller.underscore.camelize}Controller".constantize : nil
+        action_method_name = action&.to_sym
         source_path =
-          if !action_method_name.nil? && controller_class.method_defined?(action_method_name)
+          if !action_method_name.nil? && controller_class&.method_defined?(action_method_name)
             controller_class.instance_method(action_method_name).source_location&.[](0)
           else
             ""

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -17,7 +17,7 @@ describe "Chusaku" do
     out, _err = capture_io { exit_code = Chusaku.call(error_on_annotation: true) }
 
     assert_equal(1, exit_code)
-    assert_equal(4, File.written_files.count)
+    assert_equal(5, File.written_files.count)
     assert_includes(out, "Exited with status code 1.")
   end
 
@@ -53,13 +53,13 @@ describe "Chusaku" do
     engine_path = "#{Rails.root}/engine/app/controllers"
 
     assert_equal(0, exit_code)
-    assert_equal(4, files.count)
+    assert_equal(5, files.count)
     refute_includes(files, "#{app_path}/api/burritos_controller.rb")
 
     expected =
       <<~HEREDOC
         module Api
-          class CakesController < ApplicationController
+          class CakesController < PastriesController
             # This route's GET action should be named the same as its PUT action,
             # even though only the PUT action is named.
             # @route GET /api/cakes/inherit (inherit)
@@ -108,6 +108,18 @@ describe "Chusaku" do
         end
       HEREDOC
     assert_equal(expected, files["#{app_path}/api/tacos_controller.rb"])
+
+    expected =
+      <<~HEREDOC
+        class PastriesController < ApplicationController
+          # This should be annotated for each child controller that inherits from this class.
+          # @route GET /api/cakes (cakes)
+          # @route GET /api/croissants (croissants)
+          def index
+          end
+        end
+      HEREDOC
+    assert_equal(expected, files["#{app_path}/pastries_controller.rb"])
 
     expected =
       <<~HEREDOC
@@ -165,7 +177,7 @@ describe "Chusaku" do
     out, = capture_io { exit_code = Chusaku.call(args) }
 
     assert_equal(0, exit_code)
-    assert_equal(3, File.written_files.count)
+    assert_equal(4, File.written_files.count)
     assert_equal("Chusaku has finished running.\n", out)
   end
 end

--- a/test/mock/app/controllers/api/cakes_controller.rb
+++ b/test/mock/app/controllers/api/cakes_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class CakesController < ApplicationController
+  class CakesController < PastriesController
     # This route's GET action should be named the same as its PUT action,
     # even though only the PUT action is named.
     def inherit

--- a/test/mock/app/controllers/api/croissants_controller.rb
+++ b/test/mock/app/controllers/api/croissants_controller.rb
@@ -1,0 +1,2 @@
+class Api::CroissantsController < PastriesController
+end

--- a/test/mock/app/controllers/pastries_controller.rb
+++ b/test/mock/app/controllers/pastries_controller.rb
@@ -1,0 +1,5 @@
+class PastriesController < ApplicationController
+  # This should be annotated for each child controller that inherits from this class.
+  def index
+  end
+end

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -10,9 +10,11 @@ require_relative "engine"
 require_relative "route_helper"
 
 require_relative "app/controllers/application_controller"
+require_relative "app/controllers/pastries_controller"
 require_relative "app/controllers/waterlilies_controller"
 require_relative "app/controllers/api/burritos_controller"
 require_relative "app/controllers/api/cakes_controller"
+require_relative "app/controllers/api/croissants_controller"
 require_relative "app/controllers/api/tacos_controller"
 
 module Rails
@@ -47,6 +49,20 @@ module Rails
           verb: "PUT",
           path: "/api/cakes/inherit(.:format)",
           name: "inherit"
+      routes.push \
+        mock_route \
+          controller: "api/cakes",
+          action: "index",
+          verb: "GET",
+          path: "/api/cakes(.:format)",
+          name: "cakes"
+      routes.push \
+        mock_route \
+          controller: "api/croissants",
+          action: "index",
+          verb: "GET",
+          path: "/api/croissants(.:format)",
+          name: "croissants"
       routes.push \
         mock_route \
           controller: "api/tacos",

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -6,49 +6,139 @@ describe "Chusaku::Routes" do
       {
         "api/burritos" => {
           "create" => [
-            {verb: "POST", path: "/api/burritos", name: "burritos", defaults: {}}
+            {
+              verb: "POST",
+              path: "/api/burritos",
+              name: "burritos",
+              defaults: {},
+              source_path: Api::BurritosController.instance_method(:create).source_location.first
+            }
           ]
         },
         "api/cakes" => {
           "inherit" => [
-            {verb: "GET", path: "/api/cakes/inherit", name: "inherit", defaults: {}},
-            {verb: "PUT", path: "/api/cakes/inherit", name: "inherit", defaults: {}}
+            {
+              verb: "GET",
+              path: "/api/cakes/inherit",
+              name: "inherit",
+              defaults: {},
+              source_path: Api::CakesController.instance_method(:inherit).source_location.first
+            },
+            {
+              verb: "PUT",
+              path: "/api/cakes/inherit",
+              name: "inherit",
+              defaults: {},
+              source_path: Api::CakesController.instance_method(:inherit).source_location.first
+            }
           ],
           "index" => [
-            {verb: "GET", path: "/api/cakes", name: "cakes", defaults: {}}
+            {
+              verb: "GET",
+              path: "/api/cakes",
+              name: "cakes",
+              defaults: {},
+              source_path: Api::CakesController.instance_method(:index).source_location.first
+            }
           ]
         },
         "api/croissants" => {
           "index" => [
-            {verb: "GET", path: "/api/croissants", name: "croissants", defaults: {}}
+            {
+              verb: "GET",
+              path: "/api/croissants",
+              name: "croissants",
+              defaults: {},
+              source_path: Api::CroissantsController.instance_method(:index).source_location.first
+            }
           ]
         },
         "api/tacos" => {
           "show" => [
-            {verb: "GET", path: "/", name: "root", defaults: {}},
-            {verb: "GET", path: "/api/tacos/:id", name: "taco", defaults: {}}
+            {
+              verb: "GET",
+              path: "/",
+              name: "root",
+              defaults: {},
+              source_path: Api::TacosController.instance_method(:show).source_location.first
+            },
+            {
+              verb: "GET",
+              path: "/api/tacos/:id",
+              name: "taco",
+              defaults: {},
+              source_path: Api::TacosController.instance_method(:show).source_location.first
+            }
           ],
           "create" => [
-            {verb: "POST", path: "/api/tacos", name: "tacos", defaults: {}}
+            {
+              verb: "POST",
+              path: "/api/tacos",
+              name: "tacos",
+              defaults: {},
+              source_path: Api::TacosController.instance_method(:create).source_location.first
+            }
           ],
           "update" => [
-            {verb: "PUT", path: "/api/tacos/:id", name: "taco", defaults: {}},
-            {verb: "PATCH", path: "/api/tacos/:id", name: "taco", defaults: {}}
+            {
+              verb: "PUT",
+              path: "/api/tacos/:id",
+              name: "taco",
+              defaults: {},
+              source_path: Api::TacosController.instance_method(:update).source_location.first
+            },
+            {
+              verb: "PATCH",
+              path: "/api/tacos/:id",
+              name: "taco",
+              defaults: {},
+              source_path: Api::TacosController.instance_method(:update).source_location.first
+            }
           ]
         },
         "waterlilies" => {
           "show" => [
-            {verb: "GET", path: "/waterlilies/:id", name: "waterlilies", defaults: {}},
-            {verb: "GET", path: "/waterlilies/:id", name: "waterlilies2", defaults: {}},
-            {verb: "GET", path: "/waterlilies/:id", name: "waterlilies_blue", defaults: {blue: true}}
+            {
+              verb: "GET",
+              path: "/waterlilies/:id",
+              name: "waterlilies",
+              defaults: {},
+              source_path: WaterliliesController.instance_method(:show).source_location.first
+            },
+            {
+              verb: "GET",
+              path: "/waterlilies/:id",
+              name: "waterlilies2",
+              defaults: {},
+              source_path: WaterliliesController.instance_method(:show).source_location.first
+            },
+            {
+              verb: "GET",
+              path: "/waterlilies/:id",
+              name: "waterlilies_blue",
+              defaults: {blue: true},
+              source_path: WaterliliesController.instance_method(:show).source_location.first
+            }
           ],
           "one_off" => [
-            {verb: "GET", path: "/one-off", name: nil, defaults: {}}
+            {
+              verb: "GET",
+              path: "/one-off",
+              name: nil,
+              defaults: {},
+              source_path: WaterliliesController.instance_method(:one_off).source_location.first
+            }
           ]
         },
         "cars" => {
           "create" => [
-            {verb: "POST", path: "/engine/cars", name: "car", defaults: {}}
+            {
+              verb: "POST",
+              path: "/engine/cars",
+              name: "car",
+              defaults: {},
+              source_path: CarsController.instance_method(:create).source_location.first
+            }
           ]
         }
       }

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -13,6 +13,14 @@ describe "Chusaku::Routes" do
           "inherit" => [
             {verb: "GET", path: "/api/cakes/inherit", name: "inherit", defaults: {}},
             {verb: "PUT", path: "/api/cakes/inherit", name: "inherit", defaults: {}}
+          ],
+          "index" => [
+            {verb: "GET", path: "/api/cakes", name: "cakes", defaults: {}}
+          ]
+        },
+        "api/croissants" => {
+          "index" => [
+            {verb: "GET", path: "/api/croissants", name: "croissants", defaults: {}}
           ]
         },
         "api/tacos" => {


### PR DESCRIPTION
# Issue

Closes #57.

# Overview

This PR updates Chusaku to account for controller actions that are passed down through object-oriented class inheritance. The high-level changes include:

- Store `#source_location` data in `Chusaku::Routes` as `source_path`.
- Map source paths to corresponding actions data and loop over that to annotate files.
- Update tests.