### PR TITLE
build: account for Ruby v3.4

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,11 +4,11 @@ jobs:
   standard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
           bundler-cache: true
       - name: Run Standard
         run: bundle exec standardrb --fail-level A

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake test

--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |spec|
     spec.metadata["source_code_uri"] = spec.homepage
     spec.metadata["changelog_uri"] = spec.homepage
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-          "public gem pushes."
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
   # Specify which files should be added to the gem when it is released.
@@ -39,10 +38,10 @@ Gem::Specification.new do |spec|
   spec.executables = "chusaku"
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "minitest", "~> 5.14"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "standardrb", "~> 1.0"
+  spec.add_development_dependency "bundler", "~> 2.6"
+  spec.add_development_dependency "minitest", "~> 5.25"
+  spec.add_development_dependency "rake", "~> 13.2"
+  spec.add_development_dependency "standard", "~> 1.31"
 
   spec.add_dependency "railties", ">= 3.0"
 end

--- a/chusaku.gemspec
+++ b/chusaku.gemspec
@@ -38,10 +38,10 @@ Gem::Specification.new do |spec|
   spec.executables = "chusaku"
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.6"
-  spec.add_development_dependency "minitest", "~> 5.25"
-  spec.add_development_dependency "rake", "~> 13.2"
-  spec.add_development_dependency "standard", "~> 1.31"
+  spec.add_development_dependency "bundler", "~> 2"
+  spec.add_development_dependency "minitest", "~> 5"
+  spec.add_development_dependency "rake", "~> 13"
+  spec.add_development_dependency "standard", "~> 1"
 
   spec.add_dependency "railties", ">= 3.0"
 end


### PR DESCRIPTION
# Overview

With the Christmas release of Ruby 3.4, this is to make sure the gem's CI is updated with it in mind. Also includes a drive-by update of development dependencies.