### PR TITLE
feat(config): allow choosing format with a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ def update
 end
 ```
 
+With `--format=rdoc`:
+
+```ruby
+# Route:: GET /waterlilies/:id (waterlily)
+def show
+  # ...
+end
+
+# Route:: PATCH /waterlilies/:id (waterlily)
+# Route:: PUT /waterlilies/:id (waterlily)
+def update
+  # ...
+end
+```
+
 Based on your `routes.rb` file!
 
 
@@ -54,6 +69,7 @@ Usage: chusaku [options]
         --exit-with-error-on-annotation Fail if any file was annotated
     -c, --controllers-pattern=GLOB      Specify alternative controller files glob pattern
     -e, --exclusion-pattern=GLOB        Specify controller files exclusion glob pattern
+    -f, --format=FORMAT                 Annotation style: yard (default) or rdoc
         --verbose                       Print all annotated files
     -v, --version                       Show Chusaku version number and quit
     -h, --help                          Show this help message and quit

--- a/lib/chusaku.rb
+++ b/lib/chusaku.rb
@@ -105,6 +105,7 @@ module Chusaku
       return unless group[:type] == :comment
 
       group[:body] = group[:body].gsub(/^\s*#\s*@route.*$\n/, "")
+      group[:body] = group[:body].gsub(/^\s*#\s*Route::.*$\n/, "")
       group[:body] =
         group[:body].gsub(%r{^\s*# (GET|POST|PATCH/PUT|DELETE) /\S+$\n}, "")
     end
@@ -134,7 +135,8 @@ module Chusaku
     # @param source_path [String] Path to controller file
     # @return [String] "@route <verb> <path> {<defaults>} (<name>)"
     def annotate_route(verb:, path:, name:, defaults:, source_path:)
-      annotation = "@route #{verb} #{path}"
+      prefix = (@flags[:format] == :rdoc) ? "Route::" : "@route"
+      annotation = "#{prefix} #{verb} #{path}"
       if defaults&.any?
         defaults_str =
           defaults

--- a/lib/chusaku/cli.rb
+++ b/lib/chusaku/cli.rb
@@ -58,6 +58,7 @@ module Chusaku
         add_error_on_annotation_flag(opts)
         add_controllers_pattern_flag(opts)
         add_exclusion_pattern_flag(opts)
+        add_format_flag(opts)
         add_verbose_flag(opts)
         add_version_flag(opts)
         add_help_flag(opts)
@@ -101,6 +102,16 @@ module Chusaku
     def add_exclusion_pattern_flag(opts)
       opts.on("-e", "--exclusion-pattern", "=GLOB", "Specify controller files exclusion glob pattern") do |value|
         @options[:exclusion_pattern] = value
+      end
+    end
+
+    # Adds `--format` flag.
+    #
+    # @param opts [OptionParser] OptionParser instance
+    # @return [void]
+    def add_format_flag(opts)
+      opts.on("-f", "--format=FORMAT", %w[yard rdoc], "Annotation style: yard (default) or rdoc") do |value|
+        @options[:format] = value.to_sym
       end
     end
 

--- a/test/chusaku_test.rb
+++ b/test/chusaku_test.rb
@@ -180,4 +180,68 @@ describe "Chusaku" do
     assert_equal(4, File.written_files.count)
     assert_equal("Chusaku has finished running.\n", out)
   end
+
+  it "annotates with RDoc format when `format: :rdoc` is passed" do
+    exit_code = 0
+
+    capture_io { exit_code = Chusaku.call(format: :rdoc) }
+    files = File.written_files
+    app_path = "#{Rails.root}/app/controllers"
+
+    assert_equal(0, exit_code)
+
+    expected =
+      <<~HEREDOC
+        class WaterliliesController < ApplicationController
+          # Route:: GET /waterlilies/:id (waterlilies)
+          # Route:: GET /waterlilies/:id (waterlilies2)
+          # Route:: GET /waterlilies/:id {blue: true} (waterlilies_blue)
+          def show
+          end
+
+          # Route:: GET /one-off
+          def one_off
+          end
+        end
+      HEREDOC
+    assert_equal(expected, files["#{app_path}/waterlilies_controller.rb"])
+
+    expected =
+      <<~HEREDOC
+        module Api
+          class TacosController < ApplicationController
+            # Route:: GET / (root)
+            # Route:: GET /api/tacos/:id (taco)
+            def show
+            end
+
+            # This is an example of generated annotations that come with Rails 6
+            # scaffolds. These should be replaced by Chusaku annotations.
+            # Route:: POST /api/tacos (tacos)
+            def create
+            end
+
+            # Update all the tacos!
+            # We should not see a duplicate @route in this comment block.
+            # But this should remain (@route), because it's just words.
+            # Route:: PUT /api/tacos/:id (taco)
+            # Route:: PATCH /api/tacos/:id (taco)
+            def update
+            end
+
+            # This route doesn't exist, so it should be deleted.
+            def destroy
+              puts("Tacos are indestructible")
+            end
+
+            private
+
+            def tacos_params
+              params.require(:tacos).permit(:carnitas)
+            end
+          end
+        end
+      HEREDOC
+    assert_equal(expected, files["#{app_path}/api/tacos_controller.rb"])
+  end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -116,4 +116,42 @@ describe "Chusaku::CLI" do
       assert_equal({exclusion_pattern: "**/*_not_controller.rb"}, cli.options)
     end
   end
+
+  it "implements a format flag" do
+    # --format=rdoc
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["--format=rdoc"]))
+      end
+      assert_equal({format: :rdoc}, cli.options)
+    end
+
+    # -f rdoc
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["-f", "rdoc"]))
+      end
+      assert_equal({format: :rdoc}, cli.options)
+    end
+
+    # --format=yard
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      capture_io do
+        assert_equal(0, cli.call(["--format=yard"]))
+      end
+      assert_equal({format: :yard}, cli.options)
+    end
+  end
+
+  it "rejects an unknown format value" do
+    cli = Chusaku::CLI.new
+    cli.stub(:check_for_rails_project, nil) do
+      assert_raises(OptionParser::InvalidArgument) do
+        cli.call(["--format=bogus"])
+      end
+    end
+  end
 end

--- a/test/mock/app/controllers/api/tacos_controller.rb
+++ b/test/mock/app/controllers/api/tacos_controller.rb
@@ -12,6 +12,7 @@ module Api
 
     # Update all the tacos!
     # @route this should be deleted, it's not a valid route.
+    # Route:: this should also be deleted, it's a stale RDoc annotation.
     # We should not see a duplicate @route in this comment block.
     # @route PUT /api/tacos/:id (taco)
     # But this should remain (@route), because it's just words.


### PR DESCRIPTION
## Summary

Add `--format=yard|rdoc` (default: `yard`) so the gem can be used in RDoc-documented projects. With `--format=rdoc`, annotations are emitted using RDoc's labeled-list form (`Route::`) instead of the YARD tag
(`@route`):

```ruby
# Route:: GET /waterlilies/:id (waterlily)
def show; end
```

Per the [RDoc MarkupReference](https://ruby-doc.org/3.2/RDoc/MarkupReference.html#class-RDoc::MarkupReference-label-Labeled+Lists),
Label:: is the only form with real RDoc rendering semantics — it produces a `<dl>/<dt>/<dd> `block. `Label:` (single colon) is just prose, and `:directive:` forms (`:nodoc:, :call-seq:`, etc.) wrap colons on both sides, so `Route::` collides with none of them.

Backwards compatibility:
Default behavior is unchanged: with no flag (or --format=yard), output remains `# @route ....` Existing users see no diff. 
Cleanup now strips both `# @route ...` and` # Route:: ...` lines, so switching `--format` on an already-annotated project replaces the old style cleanly instead of duplicating it.