### PR TITLE
fix: engineless support

### DIFF
--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -60,14 +60,14 @@ module Chusaku
       private
 
       # Recursively populate the routes hash with information from the given Rails
-      # application. Accounts for Rails engines.
+      # application. Accounts for engines in Rails versions >= 5.2.
       #
       # @param app [Rails::Application] Result of `Rails.application`
       # @param routes [Hash] Collection of all route info
       # @return [void]
       def populate_routes(app, routes)
         app.routes.routes.each do |route|
-          if route.app.engine?
+          if route.app.respond_to?(:engine?) && route.app.engine?
             populate_routes(route.app.app, routes)
             next
           end

--- a/test/mock/engine.rb
+++ b/test/mock/engine.rb
@@ -28,11 +28,7 @@ module Engine
           path: "/engine/cars(.:format)",
           name: "car"
 
-      engine_app = Minitest::Mock.new
-      app_routes = Minitest::Mock.new
-      app_routes.expect(:routes, routes.compact)
-      engine_app.expect(:routes, app_routes)
-      engine_app
+      mock_app(routes:)
     end
 
     # Lets us call `Engine.engine?` without a skeleton Rails app.

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -131,11 +131,7 @@ module Rails
           engine: Engine,
           path: "/engine"
 
-      app = Minitest::Mock.new
-      app_routes = Minitest::Mock.new
-      app_routes.expect(:routes, routes.compact)
-      app.expect(:routes, app_routes)
-      app
+      mock_app(routes:)
     end
 
     # Lets us call `Rails.root` without a skeleton Rails app.

--- a/test/mock/route_helper.rb
+++ b/test/mock/route_helper.rb
@@ -7,6 +7,18 @@ module RouteHelper
     @@route_allowlist = route_allowlist
   end
 
+  # Builds a mock `Rails.application`.
+  #
+  # @param routes [Array<Minitest::Mock>] Routes to include
+  # @return [Minitest::Mock] Mocked application
+  def mock_app(routes:)
+    mock_routes = Minitest::Mock.new
+    mock_routes.expect(:routes, routes.compact)
+    app = Minitest::Mock.new
+    app.expect(:routes, mock_routes)
+    app
+  end
+
   # Stored procedure for mocking a new route.
   #
   # @param controller [String] Mocked controller name
@@ -14,19 +26,20 @@ module RouteHelper
   # @param verb [String] HTTP verb
   # @param path [String] Mocked Rails path
   # @param name [String] Mocked route name
+  # @param engines [Boolean] Whether engines are mocked or not
   # @param defaults [Hash] Mocked default params
   # @return [Minitest::Mock, nil] Mocked route
-  def mock_route(controller:, action:, verb:, path:, name:, defaults: {})
+  def mock_route(controller:, action:, verb:, path:, name:, engines: true, defaults: {})
     @@route_allowlist ||= []
     return if @@route_allowlist.any? && @@route_allowlist.index("#{controller}##{action}").nil?
 
     app = Minitest::Mock.new
-    app.expect(:engine?, false)
+    app.expect(:engine?, false) if engines
 
     route = Minitest::Mock.new
     route.expect(:defaults, {controller: controller, action: action, **defaults})
     route.expect(:verb, verb)
-    route.expect(:app, app)
+    2.times { route.expect(:app, app) } # Accessed twice in `Chusaku::Routes.populate_routes`
     route_path = Minitest::Mock.new
 
     # We'll be calling these particular methods more than once to test for
@@ -50,7 +63,7 @@ module RouteHelper
 
     # We'll be calling these particular methods more than once to test for
     # duplicate-removal, hence wrapping in `.times` block.
-    2.times do
+    3.times do
       route.expect(:app, engine)
     end
 

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -147,4 +147,20 @@ describe "Chusaku::Routes" do
 
     assert_equal(expected, result)
   end
+
+  it "parses routes correctly in Rails versions without engines" do
+    route = Rails.mock_route \
+      controller: "api/burritos",
+      action: "create",
+      verb: "POST",
+      path: "/api/burritos(.:format)",
+      name: "burritos",
+      engines: false
+    app = Rails.mock_app(routes: [route])
+
+    Rails.stub(:application, app) do
+      result = Chusaku::Routes.call
+      assert_equal("POST", result.dig("api/burritos", "create", 0, :verb))
+    end
+  end
 end


### PR DESCRIPTION
Fixes #65.

This fixes a bug in which Rails versions that don't have engine support weren't able to successfully run Chusaku due to the `#engine?` method not existing.