### PR TITLE
fix(routes): prevent error on missing controller

### DIFF
--- a/lib/chusaku/routes.rb
+++ b/lib/chusaku/routes.rb
@@ -195,7 +195,12 @@ module Chusaku
         action = defaults.delete(:action)
 
         controller_name = ActiveSupport::Inflector.camelize(ActiveSupport::Inflector.underscore(controller))
-        controller_class = controller ? ActiveSupport::Inflector.constantize("#{controller_name}Controller") : nil
+        controller_class =
+          begin
+            controller ? ActiveSupport::Inflector.constantize("#{controller_name}Controller") : nil
+          rescue NameError
+            nil
+          end
         action_method_name = action&.to_sym
         source_path =
           if !action_method_name.nil? && controller_class&.method_defined?(action_method_name)

--- a/test/mock/rails.rb
+++ b/test/mock/rails.rb
@@ -127,6 +127,13 @@ module Rails
           path: "/one-off",
           name: nil
       routes.push \
+        mock_route \
+          controller: "non_existent",
+          action: "non_existent",
+          verb: "POST",
+          path: "/non-existent",
+          name: nil
+      routes.push \
         mock_engine \
           engine: Engine,
           path: "/engine"

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -130,6 +130,17 @@ describe "Chusaku::Routes" do
             }
           ]
         },
+        "non_existent" => {
+          "non_existent" => [
+            {
+              verb: "POST",
+              path: "/non-existent",
+              name: nil,
+              defaults: {},
+              source_path: ""
+            }
+          ]
+        },
         "cars" => {
           "create" => [
             {


### PR DESCRIPTION
Fixes #67. This prevents an error from being thrown if a codebase is missing a controller for a defined route. While it's nice that Chusaku previously threw in these cases, there are Rails-native tools for this exact purpose. In the spirit of this gem doing one thing and one thing well, I believe missing controllers shouldn't stop its execution.